### PR TITLE
Add Identity & Wallet standards placeholder files

### DIFF
--- a/ICRCs/ICRC-21/ICRC-21.md
+++ b/ICRCs/ICRC-21/ICRC-21.md
@@ -1,0 +1,5 @@
+ICRC-21 is still in draft status. Once finalized, the ICRC-21 will be available here.
+
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.

--- a/ICRCs/ICRC-25/ICRC-25.md
+++ b/ICRCs/ICRC-25/ICRC-25.md
@@ -1,0 +1,5 @@
+ICRC-25 is still in draft status. Once finalized, the ICRC-25 will be available here.
+
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.

--- a/ICRCs/ICRC-27/ICRC-27.md
+++ b/ICRCs/ICRC-27/ICRC-27.md
@@ -1,0 +1,5 @@
+ICRC-27 is still in draft status. Once finalized, the ICRC-27 will be available here.
+
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_27_get_icrc_1_subaccounts.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.

--- a/ICRCs/ICRC-29/ICRC-29.md
+++ b/ICRCs/ICRC-29/ICRC-29.md
@@ -1,0 +1,5 @@
+ICRC-29 is still in draft status. Once finalized, the ICRC-29 will be available here.
+
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_29_window_post_message_transport.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.

--- a/ICRCs/ICRC-31/ICRC-31.md
+++ b/ICRCs/ICRC-31/ICRC-31.md
@@ -1,0 +1,5 @@
+ICRC-31 is still in draft status. Once finalized, the ICRC-31 will be available here.
+
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_31_get_principals.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.

--- a/ICRCs/ICRC-32/ICRC-32.md
+++ b/ICRCs/ICRC-32/ICRC-32.md
@@ -1,0 +1,5 @@
+ICRC-32 is still in draft status. Once finalized, the ICRC-32 will be available here.
+
+To read [the draft]https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_32_sign_challenge.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.

--- a/ICRCs/ICRC-34/ICRC-34.md
+++ b/ICRCs/ICRC-34/ICRC-34.md
@@ -1,0 +1,5 @@
+ICRC-34 is still in draft status. Once finalized, the ICRC-34 will be available here.
+
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_34_get_delegation.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.

--- a/ICRCs/ICRC-49/ICRC-49.md
+++ b/ICRCs/ICRC-49/ICRC-49.md
@@ -1,0 +1,5 @@
+ICRC-49 is still in draft status. Once finalized, the ICRC-49 will be available here.
+
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_49_call_canister.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+
+For historical changes and discussions please see the git history of the draft file.


### PR DESCRIPTION
This PR adds the placeholder files for the finalized standards to exist. This allows to already link to the future final standard (and find the draft from there) while not loosing the flexibility that we have (and need) by working in a separate repository.