### PR TITLE
Fix link to ICRC-27

### DIFF
--- a/ICRCs/ICRC-27/ICRC-27.md
+++ b/ICRCs/ICRC-27/ICRC-27.md
@@ -1,5 +1,5 @@
 ICRC-27 is still in draft status. Once finalized, the ICRC-27 will be available here.
 
-To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_27_get_icrc_1_subaccounts.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_27_get_icrc_1_accounts.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
 
 For historical changes and discussions please see the git history of the draft file.


### PR DESCRIPTION
The ICRC-27 draft has recently been moved. This PR fixes the link in the placeholder file.