### PR TITLE
Fix link in ICRC-21 placeholder

### DIFF
--- a/ICRCs/ICRC-21/ICRC-21.md
+++ b/ICRCs/ICRC-21/ICRC-21.md
@@ -1,5 +1,5 @@
 ICRC-21 is still in draft status. Once finalized, the ICRC-21 will be available here.
 
-To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
+To read [the draft](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/ICRC-21/icrc_21_consent_msg.md) and join the discussion please visit the ["Identity and Wallet Standards" working group repository](https://github.com/dfinity/wg-identity-authentication).
 
 For historical changes and discussions please see the git history of the draft file.


### PR DESCRIPTION
The ICRC-21 draft has been moved. This PR fixes the link.