### PR TITLE
Standard for index discovery from ledgers

### DIFF
--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -41,7 +41,7 @@ The metadata entry `icrc106:index_principal` and the `icrc106_get_index_principa
 - The `icrc106:index_principal` metadata entry MUST represent the textual form of the principal returned by the `icrc106_get_index_principal` method.  
 - The `icrc106_get_index_principal` method MUST return the principal corresponding to the index canister associated with the ledger, as specified in the `icrc106:index_principal` metadata entry.
 
-This requirement ensures that both mechanisms reliably point to the same index canister. Implementations
+This requirement ensures that both mechanisms reliably point to the same index canister. 
 
 
 ## 3. Index Canister Interface

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -188,12 +188,16 @@ The index canister provides methods to facilitate querying of transaction histor
 - **Typical Use Case**: Used for monitoring the health and synchronization status of the index, this method is helpful for determining whether the index has fully caught up with the ledger and is operational.
 
 
-## Undocumented Methods
-The index canister described in this standard implements several methods beyond those explicitly documented here. While `get_account_transactions`, `list_subaccounts`, `ledger_id`, and `status` are the primary focus of this standard due to their direct relevance to wallet services, the following methods are also part of the index canister interface:
+## Optional Methods
 
-* `get_blocks`: Allows fetching raw block data for a specified range of indices.
-* `get_fee_collectors_ranges`: Provides detailed information about fee collection, including the accounts and block ranges associated with collected fees.
-* `icrc1_balance_of`: Enables querying the token balance of specific accounts.
+While the methods defined in this standard are sufficient for compliance with ICRC-106, certain implementations of the index canister may include additional methods to extend functionality. These methods are not required by ICRC-106 but may be present for advanced use cases:
+
+- **`get_blocks`**: Fetches raw block data for a specified range of indices. This is useful for applications requiring detailed historical data.
+- **`get_fee_collectors_ranges`**: Provides detailed information about fee collection, including accounts and associated block ranges.
+- **`icrc1_balance_of`**: Queries the token balance of specific accounts. This method is commonly used for token management in wallets and tools.
+
+These methods, while potentially helpful, are outside the scope of ICRC-106 and are not guaranteed to be present in all index canisters. Developers should refer to the documentation of the specific implementation they are working with for details on these optional methods.
+
 
 
 

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -8,9 +8,9 @@
 
 Wallet applications and token management tools often need to retrieve both token metadata and transaction history for a given principal. However, identifying an associated index canister for ICRC-1 tokens is currently unstandardized, leading to inconsistencies in wallet integrations.
 
-**ICRC-106** introduces a standard approach for:
-1. Indicating the presence of an index canister for ICRC-1 tokens through ledger metadata.
-2. Defining a minimal interface for the index canister to facilitate querying transaction history in a consistent manner.
+Standard **ICRC-106** :
+1. Introduces a standard approach for indicating the presence of an index canister for ICRC-1 tokens through ledger metadata.
+2. Defines a minimal interface for the associated index canister to facilitate querying transaction history in a consistent manner.
 
 This draft standard aims to improve interoperability, simplify wallet integrations, and enable token-related applications to reliably access transaction histories.  It acts as a placeholder and documentation source until a more comprehensive standard for index canisters will be developed.
 
@@ -97,7 +97,7 @@ type Approve = record {
     memo : opt blob;
     created_at_time : opt nat64;
     amount : Tokens;
-    expected_allowance : opt Tokens;
+    expected_allowance : opt nat;
     expires_at : opt nat64;
     spender : Account;
 };

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -12,7 +12,7 @@ Wallet applications and token management tools often need to retrieve both token
 1. Indicating the presence of an index canister for ICRC-1 tokens through ledger metadata.
 2. Defining a minimal interface for the index canister to facilitate querying transaction history in a consistent manner.
 
-This standard aims to improve interoperability, simplify wallet integrations, and enable token-related applications to reliably access transaction histories.
+This draft standard aims to improve interoperability, simplify wallet integrations, and enable token-related applications to reliably access transaction histories.  It will act as a placeholder and documentation source until a more comprehensive standard for index canisters will be developed.
 
 
 ## 2. Metadata
@@ -30,7 +30,7 @@ Additionally, the ledger MUST provide the following metadata entry retrievable v
 These metadata entries allow clients to discover and interact with the index canister associated with a ledger and can be retrieved using method `icrc1_metadata` defined by the ICRC-1 standard.
 
 
-Compliant ledgers MAY also implement the following optional endpoint for programmatically retrieving the index principal:
+Compliant ledgers MUST also implement the following endpoint for programmatically retrieving the index principal:
 
 ```candid
 icrc106_get_index_principal: () -> (principal) query;
@@ -96,7 +96,7 @@ service : {
 }
 ```
 
-This interface defines the minimal set of methods that index canisters must support for integration.
+This interface defines the minimal set of methods that index canisters must support for integration.  The behavior of the methods that are offered is as follows. 
 
 ## 4. Implementation Considerations
 

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -53,7 +53,7 @@ type Tokens = nat;
 
 type BlockIndex = nat;
 
-type SubAccount = blob;
+type Subaccount = blob;
 
 type Account = record {
     owner: principal;

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -85,7 +85,7 @@ type Transfer = record {
 };
 
 type Approve = record {
-    fee : opt nat;
+    fee : opt Tokens;
     from : Account;
     memo : opt vec nat8;
     created_at_time : opt nat64;

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -41,7 +41,7 @@ The metadata entry `icrc106:index_principal` and the `icrc106_get_index_principa
 - The `icrc106:index_principal` metadata entry MUST represent the textual form of the principal returned by the `icrc106_get_index_principal` method.  
 - The `icrc106_get_index_principal` method MUST return the principal corresponding to the index canister associated with the ledger, as specified in the `icrc106:index_principal` metadata entry.
 
-This requirement ensures that both mechanisms reliably point to the same index canister. 
+This requirement ensures that both mechanisms reliably point to the same index canister.
 
 
 ## 3. Index Canister Interface
@@ -53,7 +53,7 @@ type Tokens = nat;
 
 type BlockIndex = nat;
 
-type Subaccount = blob;
+type SubAccount = blob;
 
 type Account = record {
     owner: principal;
@@ -68,17 +68,24 @@ type GetAccountTransactionsArgs = record {
 
 type Burn = record {
     from : Account;
-    memo : opt vec nat8;
+    memo : opt blob;
     created_at_time : opt nat64;
-    amount : nat;
+    amount : Tokens;
     spender : opt Account;
+};
+
+type Mint = record {
+  to : Account;
+  memo : opt blob;
+  created_at_time : opt nat64;
+  amount : Tokens;
 };
 
 type Transfer = record {
     to : Account;
     fee : opt Tokens;
     from : Account;
-    memo : opt vec nat8;
+    memo : opt blob;
     created_at_time : opt nat64;
     amount : Tokens;
     spender : opt Account;
@@ -87,9 +94,9 @@ type Transfer = record {
 type Approve = record {
     fee : opt Tokens;
     from : Account;
-    memo : opt vec nat8;
+    memo : opt blob;
     created_at_time : opt nat64;
-    amount : nat;
+    amount : Tokens;
     expected_allowance : opt Tokens;
     expires_at : opt nat64;
     spender : Account;
@@ -109,13 +116,20 @@ type TransactionWithId = record {
     transaction : Transaction;
 };
 
-type GetTransactionsResult = variant {
-    Ok: record {
-        balance: Tokens; // Current balance of the account.
-        transactions: vec TransactionWithId; // List of transactions.
-        oldest_tx_id : opt BlockIndex; // The txid of the oldest transaction the account has.
-    };
-    Err: record { message: text; };
+type GetTransactions = record {
+  balance : Tokens;
+  transactions : vec TransactionWithId;
+  // The txid of the oldest transaction the account has
+  oldest_tx_id : opt BlockIndex;
+};
+
+type GetTransactionsErr = record {
+  message : text;
+};
+
+type GetAccountTransactionsResult = variant {
+  Ok : GetTransactions;
+  Err : GetTransactionsErr;
 };
 
 type ListSubaccountsArgs = record {
@@ -166,7 +180,7 @@ The index canister provides methods to facilitate querying of transaction histor
   - `owner`: The principal for which to list subaccounts.
   - `start`: *(Optional)* Specifies the subaccount to start listing from. Only subaccounts lexicographically greater than `start` will be included. If start is omitted, the method will return all subaccounts from the beginning of the list, ordered lexicographically.
 - **Output**: A vector of `SubAccount`, each representing a subaccount under the specified principal. The list will be empty if the principal has not used subaccounts, or if there are no subaccounts lexicographically higher than `start`.
-- **Typical Use Case**: Useful for wallets or tools that need to enumerate all subaccounts associated with a user, providing insight into the structure and organization of user funds.
+- **Typical Use Case**: Useful for wallets or tools that need to enumerate *all* subaccounts associated with a user. To get all subaccounts, start with no start parameter and repeatedly call the method, updating start with the last subaccount from each response, until the returned list is empty.
 
 
 ---
@@ -196,7 +210,7 @@ While the methods defined in this standard are sufficient for compliance with IC
 - **`get_fee_collectors_ranges`**: Provides detailed information about fee collection, including accounts and associated block ranges.
 - **`icrc1_balance_of`**: Queries the token balance of specific accounts. This method is commonly used for token management in wallets and tools.
 
-These methods, while potentially helpful, are outside the scope of this standard and are thus not guaranteed to be present in all ICRC-106-compliant index canisters.
+These methods, while potentially helpful, are outside the scope of ICRC-106 and are not guaranteed to be present in all index canisters. Developers should refer to the documentation of the specific implementation they are working with for details on these optional methods.
 
 
 

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -28,7 +28,8 @@ Additionally, the ledger MUST provide the following metadata entries accessible 
 - `icrc106:index_principal` (text): The textual representation of the principal of the associated index canister.
 - `icrc106:index_canister_interface` (text): A URL pointing to the Candid interface definition of the index canister.
 
-These metadata entries allow clients to discover and interact with the index canister associated with a ledger.
+These metadata entries allow clients to discover and interact with the index canister associated with a ledger and can be retrieved using method `icrc1_metadata` defined by the ICRC-1 standard.
+
 
 Compliant ledgers MAY also implement the following optional endpoint for programmatically retrieving the index principal:
 

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -96,13 +96,63 @@ service : {
 }
 ```
 
-This interface defines the minimal set of methods that index canisters must support for integration.  The behavior of the methods that are offered is as follows. 
+
+# Methods Provided by the Index Canister
+
+The index canister provides methods to facilitate querying of transaction history and metadata associated with accounts. Below is a description of the relevant methods specified in this standard, including their purpose, input, output, and typical use case.
+
+---
+
+## get_account_transactions
+- **Purpose**: Retrieves transactions associated with a specific account, starting from a specified block index and returning up to a maximum number of results. Transactions are returned in **reverse chronological order** (newest to oldest).
+- **Input**:
+  - `account`: The account (principal and optional subaccount) for which transactions are to be fetched.
+  - `start`: *(Optional)* The block index of the most recent transaction the client has already seen. If provided, only transactions with block indices **less than** this value will be returned.
+  - `max_results`: The maximum number of transactions to return.
+- **Output**:
+  - **`Ok`**: Returns a record containing:
+    - `balance`: The current token balance of the account.
+    - `transactions`: A vector of `TransactionWithId`, each containing:
+      - `id`: The block index of the transaction.
+      - `transaction`: Details of the transaction (burn, transfer, approval, and timestamp).
+    - `oldest_tx_id`: *(Optional)* The block index of the oldest transaction for the account, or `None` if no transactions exist.
+  - **`Err`**: Returns an error message explaining why the request could not be completed (e.g., invalid input).
+- **Typical Use Case**: This method is often used by wallets to display transaction history and update account balances. It also supports paginated transaction retrieval for efficient history browsing.
+
+---
+
+## ledger_id
+- **Purpose**: Retrieves the principal of the ledger canister that the index is linked to.
+- **Input**: None.
+- **Output**: The `principal` of the ledger canister.
+- **Typical Use Case**: This method is primarily used for validating the relationship between the index and the ledger, ensuring they are correctly linked, and facilitating integrations requiring the ledger’s identity.
+
+---
+
+## list_subaccounts
+- **Purpose**: Lists all subaccounts associated with a specified principal.
+- **Input**:
+  - `owner`: The principal for which to list subaccounts.
+  - `start`: *(Optional)* Specifies the subaccount to start listing from. Only subaccounts lexicographically greater than `start` will be included.
+- **Output**: A vector of `SubAccount`, each representing a subaccount under the specified principal.
+- **Typical Use Case**: Useful for wallets or tools that need to enumerate all subaccounts associated with a user, providing insight into the structure and organization of user funds.
+
+---
+
+## status
+- **Purpose**: Retrieves the synchronization and operational status of the index canister.
+- **Input**: None.
+- **Output**: A `Status` record containing:
+  - `num_blocks_synced`: The total number of blocks that have been successfully synchronized by the index canister.
+- **Typical Use Case**: Used for monitoring the health and synchronization status of the index, this method is helpful for determining whether the index has fully caught up with the ledger and is operational.
+
+
+
 
 ## 4. Implementation Considerations
 
 Implementers should ensure that:
 - The `icrc106:index_principal` metadata entry accurately reflects the principal of the associated index canister.
-- The `icrc106:index_canister_interface` metadata entry points to a location where the Candid interface definition of the index canister is accessible.
 - Any changes to the index canister interface should maintain backward compatibility.
 
 By adhering to ICRC-106, ledger canisters provide a standardized mechanism for clients to discover and interact with their associated index canisters, improving integration and user experience within the Internet Computer ecosystem.

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -23,10 +23,9 @@ A ledger implementing ICRC-106 MUST include the following entry in the output of
 record { name = "ICRC-106"; url = "https://github.com/dfinity/ICRC-1/standards/ICRC-106" }
 ```
 
-Additionally, the ledger MUST provide the following metadata entries accessible via the `icrc1_metadata` method:
+Additionally, the ledger MUST provide the following metadata entry retrievable via the `icrc1_metadata` method:
 
 - `icrc106:index_principal` (text): The textual representation of the principal of the associated index canister.
-- `icrc106:index_canister_interface` (text): A URL pointing to the Candid interface definition of the index canister.
 
 These metadata entries allow clients to discover and interact with the index canister associated with a ledger and can be retrieved using method `icrc1_metadata` defined by the ICRC-1 standard.
 
@@ -43,6 +42,10 @@ The index canister associated with the ledger is expected to implement the follo
 
 ```candid
 type Tokens = nat;
+
+type BlockIndex = nat;
+
+type SubAccount = blob;
 
 type Account = record {
     owner: principal;
@@ -75,10 +78,21 @@ type GetTransactionsResult = variant {
     Err: record { message: text; };
 };
 
+type ListSubaccountsArgs = record {
+    owner: principal;
+    start: opt SubAccount;
+};
+
+type Status = record {
+    num_blocks_synced : BlockIndex;
+};
+
 service : {
     get_account_transactions: (GetAccountTransactionsArgs) -> (GetTransactionsResult) query;
     icrc1_balance_of: (Account) -> (Tokens) query;
     ledger_id: () -> (principal) query;
+    list_subaccounts : (ListSubaccountsArgs) -> (vec SubAccount) query;
+    status : () -> (Status) query;
 }
 ```
 

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -20,7 +20,7 @@ This draft standard aims to improve interoperability, simplify wallet integratio
 A ledger implementing ICRC-106 MUST include the following entry in the output of the `icrc1_supported_standards` method:
 
 ```candid
-record { name = "ICRC-106"; url = "https://github.com/dfinity/ICRC-1/standards/ICRC-106" }
+record { name = "ICRC-106"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-106" }
 ```
 
 Additionally, the ledger MUST provide the following metadata entry retrievable via the `icrc1_metadata` method:

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -196,7 +196,7 @@ While the methods defined in this standard are sufficient for compliance with IC
 - **`get_fee_collectors_ranges`**: Provides detailed information about fee collection, including accounts and associated block ranges.
 - **`icrc1_balance_of`**: Queries the token balance of specific accounts. This method is commonly used for token management in wallets and tools.
 
-These methods, while potentially helpful, are outside the scope of ICRC-106 and are not guaranteed to be present in all index canisters. Developers should refer to the documentation of the specific implementation they are working with for details on these optional methods.
+These methods, while potentially helpful, are outside the scope of this standard and are thus not guaranteed to be present in all ICRC-106-compliant index canisters.
 
 
 

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -14,17 +14,80 @@ Wallet applications and token management tools often need to retrieve both token
 
 This standard aims to improve interoperability, simplify wallet integrations, and enable token-related applications to reliably access transaction histories.
 
----
 
 ## 2. Metadata
 
-To indicate the presence of an index canister, ledgers implementing ICRC-106 MUST include the following metadata entry:
-
-- **`icrc106:index_principal`**: Text entry representing the principal of the index canister associated with the ledger. This metadata entry enables programmatic discovery of the index canister’s principal by wallet applications and other clients.
-
-### Optional Method
-
-In addition, ledgers MAY provide an endpoint to retrieve the principal of the index canister:
+A ledger implementing ICRC-106 MUST include the following entry in the output of the `icrc1_supported_standards` method:
 
 ```candid
-icrc106_get_index_principal : () -> (opt principal) query
+record { name = "ICRC-106"; url = "https://github.com/dfinity/ICRC-1/standards/ICRC-106" }
+```
+
+Additionally, the ledger MUST provide the following metadata entries accessible via the `icrc1_metadata` method:
+
+- `icrc106:index_principal` (text): The textual representation of the principal of the associated index canister.
+- `icrc106:index_canister_interface` (text): A URL pointing to the Candid interface definition of the index canister.
+
+These metadata entries allow clients to discover and interact with the index canister associated with a ledger.
+
+Compliant ledgers MAY also implement the following optional endpoint for programmatically retrieving the index principal:
+
+```candid
+icrc106_get_index_principal: () -> (principal) query;
+```
+
+## 3. Index Canister Interface
+
+The index canister associated with the ledger is expected to implement the following minimal Candid interface:
+
+```candid
+type Tokens = nat;
+
+type Account = record {
+    owner: principal;
+    subaccount: opt blob;
+};
+
+type GetAccountTransactionsArgs = record {
+    account: Account;
+    start: opt nat; // The block index of the last transaction seen by the client.
+    max_results: nat; // Maximum number of transactions to fetch.
+};
+
+type Transaction = record {
+    burn: opt record { from: Account; amount: nat; };
+    transfer: opt record { from: Account; to: Account; amount: nat; };
+    approve: opt record { from: Account; spender: Account; amount: nat; };
+    timestamp: nat64; // Timestamp of the transaction.
+};
+
+type TransactionWithId = record {
+    id: nat; // Block index of the transaction.
+    transaction: Transaction;
+};
+
+type GetTransactionsResult = variant {
+    Ok: record {
+        balance: Tokens; // Current balance of the account.
+        transactions: vec TransactionWithId; // List of transactions.
+    };
+    Err: record { message: text; };
+};
+
+service : {
+    get_account_transactions: (GetAccountTransactionsArgs) -> (GetTransactionsResult) query;
+    icrc1_balance_of: (Account) -> (Tokens) query;
+    ledger_id: () -> (principal) query;
+}
+```
+
+This interface defines the minimal set of methods that index canisters must support for integration.
+
+## 4. Implementation Considerations
+
+Implementers should ensure that:
+- The `icrc106:index_principal` metadata entry accurately reflects the principal of the associated index canister.
+- The `icrc106:index_canister_interface` metadata entry points to a location where the Candid interface definition of the index canister is accessible.
+- Any changes to the index canister interface should maintain backward compatibility.
+
+By adhering to ICRC-106, ledger canisters provide a standardized mechanism for clients to discover and interact with their associated index canisters, improving integration and user experience within the Internet Computer ecosystem.

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -76,7 +76,7 @@ type Burn = record {
 
 type Transfer = record {
     to : Account;
-    fee : opt nat;
+    fee : opt Tokens;
     from : Account;
     memo : opt vec nat8;
     created_at_time : opt nat64;

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -1,0 +1,30 @@
+| Status |
+|:------:|
+|Draft|
+
+# ICRC-106: Standard for Associating Index Canisters with ICRC-1 Tokens
+
+## 1. Introduction
+
+Wallet applications and token management tools often need to retrieve both token metadata and transaction history for a given principal. However, identifying an associated index canister for ICRC-1 tokens is currently unstandardized, leading to inconsistencies in wallet integrations.
+
+**ICRC-106** introduces a standard approach for:
+1. Indicating the presence of an index canister for ICRC-1 tokens through ledger metadata.
+2. Defining a minimal interface for the index canister to facilitate querying transaction history in a consistent manner.
+
+This standard aims to improve interoperability, simplify wallet integrations, and enable token-related applications to reliably access transaction histories.
+
+---
+
+## 2. Metadata
+
+To indicate the presence of an index canister, ledgers implementing ICRC-106 MUST include the following metadata entry:
+
+- **`icrc106:index_principal`**: Text entry representing the principal of the index canister associated with the ledger. This metadata entry enables programmatic discovery of the index canister’s principal by wallet applications and other clients.
+
+### Optional Method
+
+In addition, ledgers MAY provide an endpoint to retrieve the principal of the index canister:
+
+```candid
+icrc106_get_index_principal : () -> (opt principal) query

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -128,7 +128,7 @@ type Status = record {
 };
 
 service : {
-    get_account_transactions: (GetAccountTransactionsArgs) -> (GetTransactionsResult) query;
+    get_account_transactions: (GetAccountTransactionsArgs) -> (GetAccountTransactionsResult) query;
     ledger_id: () -> (principal) query;
     list_subaccounts : (ListSubaccountsArgs) -> (vec SubAccount) query;
     status : () -> (Status) query;

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -90,7 +90,7 @@ type Approve = record {
     memo : opt vec nat8;
     created_at_time : opt nat64;
     amount : nat;
-    expected_allowance : opt nat;
+    expected_allowance : opt Tokens;
     expires_at : opt nat64;
     spender : Account;
 };

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -80,7 +80,7 @@ type Transfer = record {
     from : Account;
     memo : opt vec nat8;
     created_at_time : opt nat64;
-    amount : nat;
+    amount : Tokens;
     spender : opt Account;
 };
 

--- a/ICRCs/ICRC-106/ICRC-106.md
+++ b/ICRCs/ICRC-106/ICRC-106.md
@@ -12,7 +12,7 @@ Wallet applications and token management tools often need to retrieve both token
 1. Indicating the presence of an index canister for ICRC-1 tokens through ledger metadata.
 2. Defining a minimal interface for the index canister to facilitate querying transaction history in a consistent manner.
 
-This draft standard aims to improve interoperability, simplify wallet integrations, and enable token-related applications to reliably access transaction histories.  It will act as a placeholder and documentation source until a more comprehensive standard for index canisters will be developed.
+This draft standard aims to improve interoperability, simplify wallet integrations, and enable token-related applications to reliably access transaction histories.  It acts as a placeholder and documentation source until a more comprehensive standard for index canisters will be developed.
 
 
 ## 2. Metadata
@@ -116,8 +116,18 @@ The index canister provides methods to facilitate querying of transaction histor
       - `id`: The block index of the transaction.
       - `transaction`: Details of the transaction (burn, transfer, approval, and timestamp).
     - `oldest_tx_id`: *(Optional)* The block index of the oldest transaction for the account, or `None` if no transactions exist.
-  - **`Err`**: Returns an error message explaining why the request could not be completed (e.g., invalid input).
 - **Typical Use Case**: This method is often used by wallets to display transaction history and update account balances. It also supports paginated transaction retrieval for efficient history browsing.
+
+---
+
+## list_subaccounts
+- **Purpose**: Lists all subaccounts associated with a specified principal.
+- **Input**:
+  - `owner`: The principal for which to list subaccounts.
+  - `start`: *(Optional)* Specifies the subaccount to start listing from. Only subaccounts lexicographically greater than `start` will be included. If start is omitted, the method will return all subaccounts from the beginning of the list, ordered lexicographically.
+- **Output**: A vector of `SubAccount`, each representing a subaccount under the specified principal. The list will be empty if the principal has not used subaccounts, or if there are no subaccounts lexicographically higher than `start`.
+- **Typical Use Case**: Useful for wallets or tools that need to enumerate all subaccounts associated with a user, providing insight into the structure and organization of user funds.
+
 
 ---
 
@@ -127,15 +137,6 @@ The index canister provides methods to facilitate querying of transaction histor
 - **Output**: The `principal` of the ledger canister.
 - **Typical Use Case**: This method is primarily used for validating the relationship between the index and the ledger, ensuring they are correctly linked, and facilitating integrations requiring the ledger’s identity.
 
----
-
-## list_subaccounts
-- **Purpose**: Lists all subaccounts associated with a specified principal.
-- **Input**:
-  - `owner`: The principal for which to list subaccounts.
-  - `start`: *(Optional)* Specifies the subaccount to start listing from. Only subaccounts lexicographically greater than `start` will be included.
-- **Output**: A vector of `SubAccount`, each representing a subaccount under the specified principal.
-- **Typical Use Case**: Useful for wallets or tools that need to enumerate all subaccounts associated with a user, providing insight into the structure and organization of user funds.
 
 ---
 


### PR DESCRIPTION
A standard to allow for the discovery of the index canister from the  corresponding ledger. This standard will exist in draft form only since we will work on a proper ICRC standard for index canisters (which will include discoverability). 
A secondary goal for the standard is to document the interface of the current index canister. 