### PR TITLE
ICRC-107: a standard for fee collection in ICRC ledgers

### DIFF
--- a/ICRCs/ICRC-107/ICRC-107.md
+++ b/ICRCs/ICRC-107/ICRC-107.md
@@ -43,13 +43,13 @@ Additionally, the ledger **MUST** provide (at minimum) these metadata entries, r
 1. **`icrc107_fee_collector` (text)**  
    The textual representation of the principal (or account) designated as the fee collector.
 
-2. **`icrc107_fee_collection_transfers` (bool)**  
-   Indicates whether fees are collected on **transfer** transactions (`true`) or not (`false`).
+2. **`icrc107_fee_collection_transfers` (text)**  
+   Indicates whether fees are collected on **transfer** transactions ("true") or not ("false").
 
-3. **`icrc107_fee_collection_approvals` (bool)**  
-   Indicates whether fees are collected on **approve** transactions (`true`) or not (`false`).
+3. **`icrc107_fee_collection_approvals` (text)**  
+   Indicates whether fees are collected on **approve** transactions ("true") or not ("false").
 
-If a ledger has not set a fee collector, it may return an empty string or omit the metadata key for `icrc107_fee_collector`. Similarly, if fees are never collected for transfers or approvals, the corresponding booleans should be `false` or omitted.
+If a ledger has not set a fee collector, it may return an empty string or omit the metadata key for `icrc107_fee_collector`. Similarly, if fees are not collected for transfers or approvals, the values for the corresponding metadata should be "false" or omitted.
 
 ---
 

--- a/ICRCs/ICRC-107/ICRC-107.md
+++ b/ICRCs/ICRC-107/ICRC-107.md
@@ -83,11 +83,11 @@ A ledger **implementing ICRC-107** **SHOULD** expose the following methods to pr
   If this method is never called, fees are assumed to be burned by default.
 
 - **`icrc107_turn_on_fee_collector_transfers()`**  
-  Sets `icrc107_fee_collection_transfers` to `true`.  
+  Sets `icrc107_fee_collection_transfers` to "true".  
   If a valid fee collector has been set, returns `Ok(fee_collector)`. Otherwise, returns `Err` describing why it cannot be enabled.
 
 - **`icrc107_turn_on_fee_collector_approvals()`**  
-  Sets `icrc107_fee_collection_approvals` to `true`.  
+  Sets `icrc107_fee_collection_approvals` to "true".  
   If a valid fee collector has been set, returns `Ok(fee_collector)`. Otherwise, returns `Err`.
 
 These endpoints allow ledger administrators (or canister controllers) to enable fee collection for different transaction types once the fee collector account is specified.

--- a/ICRCs/ICRC-107/ICRC-107.md
+++ b/ICRCs/ICRC-107/ICRC-107.md
@@ -1,0 +1,175 @@
+| Status |
+|:------:|
+| Draft  |
+
+# ICRC-107: Fee Collection
+
+## 1. Introduction
+
+Many ICRC-based ledgers (such as **ckBTC**) already implement partial fee collection, often charging fees for **transfer** transactions but not for **approve** transactions. However, there is currently no standardized way to:
+
+1. Indicate and configure **who** should collect fees (or if fees are burned).
+2. Record fee collection information on existing ledgers.
+3. Provide clear semantics for wallets, explorers, and other integrations to **interpret** fee information.
+
+**ICRC-107** aims to address this gap by defining:
+- A set of **metadata entries** that indicate how fees are collected.
+- A **minimal interface** for setting and enabling fee collection.
+- **A backward-compatible standard** for **populating and understanding fee-collection fields** in ICRC-3 blocks corresponding to ICRC-1 and ICRC-2 transactions.
+- Guidance on how to **interpret fee collection fields**, as recorded in blocks, in a consistent way.
+
+### Non-Requirements
+This standard does **not** address or require:
+- Unsetting or removing a previously configured fee collector.
+- Having multiple fee collectors (e.g., distinct collectors for transfers vs. approvals).
+- Generalizing the mechanism for future block types beyond transfers/approvals.
+- Prescribing detailed behavior for ledger upgrades that enable fee collection.
+
+By focusing on **backward-compatible** enhancements and clear metadata, this standard allows ledgers to adopt fee collection with minimal disruption, while giving external tools a reliable way to parse and display fee-related data.
+
+---
+
+## 2. Metadata
+
+A ledger implementing **ICRC-107** **MUST** include the following entry in the output of the `icrc1_supported_standards` method (indented for display):
+
+    record {
+      name = "ICRC-107";
+      url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-107"
+    }
+
+Additionally, the ledger **MUST** provide (at minimum) these metadata entries, retrievable via the `icrc1_metadata` method:
+
+1. **`icrc107_fee_collector` (text)**  
+   The textual representation of the principal (or account) designated as the fee collector.
+
+2. **`icrc107_fee_collection_transfers` (bool)**  
+   Indicates whether fees are collected on **transfer** transactions (`true`) or not (`false`).
+
+3. **`icrc107_fee_collection_approvals` (bool)**  
+   Indicates whether fees are collected on **approve** transactions (`true`) or not (`false`).
+
+If a ledger has not set a fee collector, it may return an empty string or omit the metadata key for `icrc107_fee_collector`. Similarly, if fees are never collected for transfers or approvals, the corresponding booleans should be `false` or omitted.
+
+---
+
+## 3. Fee Collection Management Interface
+
+A ledger **implementing ICRC-107** **SHOULD** expose the following methods to programmatically configure and enable fee collection.
+
+
+    // Sets the fee collector principal/account.
+    // If not set, or set to an empty string, fees are effectively burned.
+    icrc107_set_fee_collector: (text) -> ();
+
+    // Enables fee collection for transfer transactions.
+    // Returns the currently set fee collector if successful, or an error if none is set.
+    icrc107_turn_on_fee_collector_transfers: () -> (variant {
+        Ok : text;          // The fee collector principal
+        Err : text;         // Error message
+    });
+
+    // Enables fee collection for approve transactions.
+    // Returns the currently set fee collector if successful, or an error if none is set.
+    icrc107_turn_on_fee_collector_approvals: () -> (variant {
+        Ok : text;          // The fee collector principal
+        Err : text;         // Error message
+    });
+
+### Method Semantics
+
+- **`icrc107_set_fee_collector(fee_collector: text)`**  
+  Updates the ledger’s metadata (`icrc107_fee_collector`) to the specified principal/account.  
+  If this method is never called, fees are assumed to be burned by default.
+
+- **`icrc107_turn_on_fee_collector_transfers()`**  
+  Sets `icrc107_fee_collection_transfers` to `true`.  
+  If a valid fee collector has been set, returns `Ok(fee_collector)`. Otherwise, returns `Err` describing why it cannot be enabled.
+
+- **`icrc107_turn_on_fee_collector_approvals()`**  
+  Sets `icrc107_fee_collection_approvals` to `true`.  
+  If a valid fee collector has been set, returns `Ok(fee_collector)`. Otherwise, returns `Err`.
+
+These endpoints allow ledger administrators (or canister controllers) to enable fee collection for different transaction types once the fee collector account is specified.
+
+---
+
+## 4. Fee Information in Blocks
+
+This section defines how **ICRC-107** determines whether a fee is collected or burned **exclusively** from information **contained in the blocks themselves**. No reliance on external metadata (e.g., `icrc107_fee_collector`) is assumed.
+
+### 4.1 Determining the Fee
+
+When reading or processing a block that may carry a fee, the ledger or external tools **SHOULD** apply the following logic to identify the final fee amount:
+
+1. **Check for an Explicit Transaction Fee (`tx.fee`)**  
+   - If the transaction itself contains a `fee` field (e.g., `tx.fee`), that value **SHOULD** take precedence as the fee to be applied.
+
+2. **Fallback to `effective_fee`**  
+   - If no `tx.fee` is provided, the ledger or tool **SHOULD** refer to the block’s `effective_fee` field (or an equivalent ledger-defined field) to determine the fee.
+
+3. **No Explicit Fee**  
+   - If neither `tx.fee` nor `effective_fee` is available, then the ledger MAY default the fee to zero or burn any implied fee as per its internal policy.  
+   - An **ICRC-107**-compliant ledger interprets the absence of a specified fee as no fee collected, or a fee of zero.
+
+### 4.2 Fee Collection Logic
+
+After determining the fee amount, **ICRC-107** specifies how to decide **whether** a fee is burned or collected, and if collected, **who** receives it, **based solely on block contents**:
+
+1. **Check for Fee Collector Fields**  
+   - If the block contains a direct account field (e.g., `fee_col`) or a reference field (e.g., `fee_col_block`, `app_fee_col_block`), the fee is be collected by the referenced account.
+   - If **neither** a direct account field nor a reference field is present, the fee is burned.
+
+2. **Resolving a Reference to a Previous Block**  
+   - If a reference field is used (`fee_col_block` or `app_fee_col_block`), the ledger or tool **MUST** locate that earlier block and extract the account specified there (e.g., `fee_col`).
+   - If the referenced block does not contain a valid collector the fee is burned.
+
+
+### 4.3 Recording Fee Collection in Blocks for ICRC-1 and ICRC-2 Transactions
+
+The block schema for ICRC-1 and ICRC-2 transactions are specified in the ICRC-3 standard. This section explains how to extend those schemas to include backwards compatible fee collection information.
+
+#### 4.3.1 Transfer Blocks
+
+Transfer blocks in ICRC-based ledgers can be identified by one of the following:
+- **`btype = "1xfer"`** (ICRC-1 style),
+- **`btype = "2xfer"`** (ICRC-2 style),
+- or a **transfer transaction** (`tx.op = "xfer"`).
+
+To **record and interpret** fee-collection information in these blocks:
+
+- **`fee_col` (Account)**  
+  - A direct indicator of which account receives the collected fee.
+- **`fee_col_block` (nat)**  
+  - A pointer to an earlier block where `fee_col` is explicitly set.
+
+**How to Determine Who Collects the Fee**  
+1. If `fee_col` is present in the block, that account is the collector.  
+2. If `fee_col` is absent but `fee_col_block` is present, fetch the referenced block; the `fee_col` in that block is the collector.  
+3. If neither is present, **no** collector can be inferred, and the fee is burned.
+
+#### 4.3.2 Approve Blocks
+
+Approve blocks in ICRC-based ledgers can be identified by:
+- **`btype = "2approve"`** (ICRC-2 style),
+- or a **transaction object** (`tx.op = "approve"`).
+
+To **record and interpret** fee-collection information in these blocks:
+
+- **`fee_col` (Account)**  
+  - A direct indicator of which account receives the collected fee for the approval operation.
+- **`app_fee_col_block` (nat)**  
+  - A pointer to an earlier block where `fee_col` is explicitly set for approves.
+
+**How to Determine Who Collects the Fee**  
+1. If `fee_col` is present in the block, that account is the collector.  
+2. If `fee_col` is absent but `app_fee_col_block` is present, fetch the referenced block; the `fee_col` in that block is the collector.  
+3. If neither is present, **no** collector can be inferred, and the fee is burned.
+
+---
+
+By strictly focusing on **block-level fields**:
+
+- **Ledgers** remain free to implement or omit references in blocks while still following a consistent approach for collecting or burning fees.
+- **External tools** (wallets, explorers) can determine the collector without requiring out-of-band metadata or additional method calls. If no collector info is embedded (directly or via a reference), the fee is considered burned.
+- This specification thereby ensures **ICRC-1**, **ICRC-2**, and **ICRC-3** ledgers can remain consistent with **ICRC-107** using only the fields present in each block.

--- a/ICRCs/ICRC-107/ICRC-107.md
+++ b/ICRCs/ICRC-107/ICRC-107.md
@@ -1,175 +1,197 @@
-| Status |
-|:------:|
-| Draft  |
 
-# ICRC-107: Fee Collection
+# ICRC-107: Fee Collection (Purely Block-Based)
 
-## 1. Introduction
+## 1. Introduction & Motivation
 
 Many ICRC-based ledgers (such as **ckBTC**) already implement partial fee collection, often charging fees for **transfer** transactions but not for **approve** transactions. However, there is currently no standardized way to:
 
 1. Indicate and configure **who** should collect fees (or if fees are burned).
-2. Record fee collection information on existing ledgers.
-3. Provide clear semantics for wallets, explorers, and other integrations to **interpret** fee information.
+2. Record fee collection information directly in ledger blocks.
+3. Provide clear semantics for wallets, explorers, and other integrations to **interpret** fee information in a consistent way.
 
 **ICRC-107** aims to address this gap by defining:
-- A set of **metadata entries** that indicate how fees are collected.
-- A **minimal interface** for setting and enabling fee collection.
-- **A backward-compatible standard** for **populating and understanding fee-collection fields** in ICRC-3 blocks corresponding to ICRC-1 and ICRC-2 transactions.
-- Guidance on how to **interpret fee collection fields**, as recorded in blocks, in a consistent way.
+- A mechanism to specify **fee collection details** (collector account and applicable operations) directly in blocks.
+- A **backward-compatible standard** for **recording and interpreting fee-collection fields** in ICRC-3 blocks corresponding to ICRC-1 and ICRC-2 transactions.
+- Clear rules on how fee collection information evolves over time and how subsequent blocks rely on prior updates.
 
-### Non-Requirements
-This standard does **not** address or require:
-- Unsetting or removing a previously configured fee collector.
-- Having multiple fee collectors (e.g., distinct collectors for transfers vs. approvals).
-- Generalizing the mechanism for future block types beyond transfers/approvals.
-- Prescribing detailed behavior for ledger upgrades that enable fee collection.
-
-By focusing on **backward-compatible** enhancements and clear metadata, this standard allows ledgers to adopt fee collection with minimal disruption, while giving external tools a reliable way to parse and display fee-related data.
+This design ensures that **all** fee-related information is stored entirely **on-chain** in the block history, without reliance on external metadata or specialized block types. It provides a fully self-contained, transparent standard for fee collection that simplifies integration with wallets, explorers, and other tools.
 
 ---
 
-## 2. Metadata
+## 2. Fee Collection Mechanism
 
-A ledger implementing **ICRC-107** **MUST** include the following entry in the output of the `icrc1_supported_standards` method (indented for display):
+### 2.1 Fields in Blocks
 
-    record {
-      name = "ICRC-107";
-      url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-107"
-    }
+A block **MAY** include the following fields to define or update fee collection settings:
 
-Additionally, the ledger **MUST** provide (at minimum) these metadata entries, retrievable via the `icrc1_metadata` method:
+- **`fee_col`**: An **account** (ICRC account format) to which fees are paid.  
+  **Format**:
+  ```candid
+  record {
+      principal: principal;
+      subaccount: opt blob;
+  }
+  ```
+- **`fee_ops`**: An **array of block types** (strings) for which fees **should** be collected. This standard specifies two types of blocks for which fee collection can occur: "transfer" and "approve".  
 
-1. **`icrc107_fee_collector` (text)**  
-   The textual representation of the principal (or account) designated as the fee collector.
+When a block includes either or both fields, it **overrides** the previously known settings from that point onward.
 
-2. **`icrc107_fee_collection_transfers` (text)**  
-   Indicates whether fees are collected on **transfer** transactions ("true") or not ("false").
-
-3. **`icrc107_fee_collection_approvals` (text)**  
-   Indicates whether fees are collected on **approve** transactions ("true") or not ("false").
-
-If a ledger has not set a fee collector, it may return an empty string or omit the metadata key for `icrc107_fee_collector`. Similarly, if fees are not collected for transfers or approvals, the values for the corresponding metadata should be "false" or omitted.
-
----
-
-## 3. Fee Collection Management Interface
-
-A ledger **implementing ICRC-107** **SHOULD** expose the following methods to programmatically configure and enable fee collection.
-
-
-    // Sets the fee collector principal/account.
-    // If not set, or set to an empty string, fees are effectively burned.
-    icrc107_set_fee_collector: (text) -> ();
-
-    // Enables fee collection for transfer transactions.
-    // Returns the currently set fee collector if successful, or an error if none is set.
-    icrc107_turn_on_fee_collector_transfers: () -> (variant {
-        Ok : text;          // The fee collector principal
-        Err : text;         // Error message
-    });
-
-    // Enables fee collection for approve transactions.
-    // Returns the currently set fee collector if successful, or an error if none is set.
-    icrc107_turn_on_fee_collector_approvals: () -> (variant {
-        Ok : text;          // The fee collector principal
-        Err : text;         // Error message
-    });
-
-### Method Semantics
-
-- **`icrc107_set_fee_collector(fee_collector: text)`**  
-  Updates the ledger’s metadata (`icrc107_fee_collector`) to the specified principal/account.  
-  If this method is never called, fees are assumed to be burned by default.
-
-- **`icrc107_turn_on_fee_collector_transfers()`**  
-  Sets `icrc107_fee_collection_transfers` to "true".  
-  If a valid fee collector has been set, returns `Ok(fee_collector)`. Otherwise, returns `Err` describing why it cannot be enabled.
-
-- **`icrc107_turn_on_fee_collector_approvals()`**  
-  Sets `icrc107_fee_collection_approvals` to "true".  
-  If a valid fee collector has been set, returns `Ok(fee_collector)`. Otherwise, returns `Err`.
-
-These endpoints allow ledger administrators (or canister controllers) to enable fee collection for different transaction types once the fee collector account is specified.
+#### 2.1.1 Defaults
+- If `fee_ops` is **omitted**, it defaults to `["transfer"]`.  
+- If `fee_col` is **omitted**, the previously known collector remains in effect (or none if it was never set).
 
 ---
 
-## 4. Fee Information in Blocks
+## 3. Fee Computation
 
-This section defines how **ICRC-107** determines whether a fee is collected or burned **exclusively** from information **contained in the blocks themselves**. No reliance on external metadata (e.g., `icrc107_fee_collector`) is assumed.
+### 3.1 Determining the Fee Amount
 
-### 4.1 Determining the Fee
+The fee amount in any block can be derived via:
+- An explicit `tx.fee` field in the block’s transaction.
+- A fallback `effective_fee` or other ledger-defined field if `tx.fee` is absent.
+- Zero if neither is present.
 
-When reading or processing a block that may carry a fee, the ledger or external tools **SHOULD** apply the following logic to identify the final fee amount:
+### 3.2 Collected or Burned
 
-1. **Check for an Explicit Transaction Fee (`tx.fee`)**  
-   - If the transaction itself contains a `fee` field (e.g., `tx.fee`), that value **SHOULD** take precedence as the fee to be applied.
-
-2. **Fallback to `effective_fee`**  
-   - If no `tx.fee` is provided, the ledger or tool **SHOULD** refer to the block’s `effective_fee` field (or an equivalent ledger-defined field) to determine the fee.
-
-3. **No Explicit Fee**  
-   - If neither `tx.fee` nor `effective_fee` is available, then the ledger MAY default the fee to zero or burn any implied fee as per its internal policy.  
-   - An **ICRC-107**-compliant ledger interprets the absence of a specified fee as no fee collected, or a fee of zero.
-
-### 4.2 Fee Collection Logic
-
-After determining the fee amount, **ICRC-107** specifies how to decide **whether** a fee is burned or collected, and if collected, **who** receives it, **based solely on block contents**:
-
-1. **Check for Fee Collector Fields**  
-   - If the block contains a direct account field (e.g., `fee_col`) or a reference field (e.g., `fee_col_block`, `app_fee_col_block`), the fee is be collected by the referenced account.
-   - If **neither** a direct account field nor a reference field is present, the fee is burned.
-
-2. **Resolving a Reference to a Previous Block**  
-   - If a reference field is used (`fee_col_block` or `app_fee_col_block`), the ledger or tool **MUST** locate that earlier block and extract the account specified there (e.g., `fee_col`).
-   - If the referenced block does not contain a valid collector the fee is burned.
-
-
-### 4.3 Recording Fee Collection in Blocks for ICRC-1 and ICRC-2 Transactions
-
-The block schema for ICRC-1 and ICRC-2 transactions are specified in the ICRC-3 standard. This section explains how to extend those schemas to include backwards compatible fee collection information.
-
-#### 4.3.1 Transfer Blocks
-
-Transfer blocks in ICRC-based ledgers can be identified by one of the following:
-- **`btype = "1xfer"`** (ICRC-1 style),
-- **`btype = "2xfer"`** (ICRC-2 style),
-- or a **transfer transaction** (`tx.op = "xfer"`).
-
-To **record and interpret** fee-collection information in these blocks:
-
-- **`fee_col` (Account)**  
-  - A direct indicator of which account receives the collected fee.
-- **`fee_col_block` (nat)**  
-  - A pointer to an earlier block where `fee_col` is explicitly set.
-
-**How to Determine Who Collects the Fee**  
-1. If `fee_col` is present in the block, that account is the collector.  
-2. If `fee_col` is absent but `fee_col_block` is present, fetch the referenced block; the `fee_col` in that block is the collector.  
-3. If neither is present, **no** collector can be inferred, and the fee is burned.
-
-#### 4.3.2 Approve Blocks
-
-Approve blocks in ICRC-based ledgers can be identified by:
-- **`btype = "2approve"`** (ICRC-2 style),
-- or a **transaction object** (`tx.op = "approve"`).
-
-To **record and interpret** fee-collection information in these blocks:
-
-- **`fee_col` (Account)**  
-  - A direct indicator of which account receives the collected fee for the approval operation.
-- **`app_fee_col_block` (nat)**  
-  - A pointer to an earlier block where `fee_col` is explicitly set for approves.
-
-**How to Determine Who Collects the Fee**  
-1. If `fee_col` is present in the block, that account is the collector.  
-2. If `fee_col` is absent but `app_fee_col_block` is present, fetch the referenced block; the `fee_col` in that block is the collector.  
-3. If neither is present, **no** collector can be inferred, and the fee is burned.
+After determining the fee amount, check the **current** configuration (from the most recent update):
+1. **Operation Present**: If the block’s operation (e.g., `"transfer"`, `"approve"`, etc.) is in the active list (`fee_ops`), the fee is collected by the active `fee_col`.
+2. **Operation Absent**: If the operation is **not** in the active list, the fee is burned.
+3. **No Collector**: If no collector has ever been set, fees are burned by default.
 
 ---
 
-By strictly focusing on **block-level fields**:
+## 4. Determining the Current Fee Configuration
 
-- **Ledgers** remain free to implement or omit references in blocks while still following a consistent approach for collecting or burning fees.
-- **External tools** (wallets, explorers) can determine the collector without requiring out-of-band metadata or additional method calls. If no collector info is embedded (directly or via a reference), the fee is considered burned.
-- This specification thereby ensures **ICRC-1**, **ICRC-2**, and **ICRC-3** ledgers can remain consistent with **ICRC-107** using only the fields present in each block.
+At any block height `h`, to figure out **who** collects fees and for **which** operations:
+1. **Traverse blocks** backward (or maintain an in-memory state) until you find the most recent block `< h` that included `fee_col` or `fee_ops`.
+2. The fee-collector account from that block is **active**, and the operation list from that block is **active** (defaulting to `["transfer"]` if omitted).
+3. If no such block is found, no collector is active and **all fees are burned**.
+
+---
+
+## 5. Examples
+
+### 5.1 Setting a Collector (Defaults to Transfers Only)
+
+```json
+{
+  "block_index": 100,
+  "timestamp": 1690000000,
+  "kind": "transaction",
+  "fee_col": {
+    "principal": "aaaaa-aa",
+    "subaccount": null
+  },
+  "transaction": {
+    "operation": "transfer",
+    "from": {
+      "principal": "bbbbb-bb",
+      "subaccount": null
+    },
+    "to": {
+      "principal": "ccccc-cc",
+      "subaccount": null
+    },
+    "amount": 5000,
+    "fee": 10
+  }
+}
+```
+
+- Future blocks that perform a **transfer** pay fees to `aaaaa-aa`.
+- **Approve** or other operations are not in the default set, so their fees are burned.
+
+### 5.2 Block with Approve but No Update
+
+```json
+{
+  "block_index": 101,
+  "timestamp": 1690000500,
+  "kind": "transaction",
+  "transaction": {
+    "operation": "approve",
+    "from": {
+      "principal": "bbbbb-bb",
+      "subaccount": null
+    },
+    "spender": {
+      "principal": "ccccc-cc",
+      "subaccount": null
+    },
+    "amount": 3000
+  }
+}
+```
+
+- No new fee settings. The **previous** block #100 had `["transfer"]` as the fee-bearing operation.
+- This is an `"approve"` operation, **not** in `["transfer"]`, so the fee (if any) is burned.
+
+### 5.3 Updating Collector and Adding Approves
+
+```json
+{
+  "block_index": 150,
+  "timestamp": 1690001000,
+  "kind": "transaction",
+  "fee_col": {
+    "principal": "zzzzz-zz",
+    "subaccount": null
+  },
+  "fee_ops": ["transfer", "approve"],
+  "transaction": {
+    "operation": "approve",
+    "from": {
+      "principal": "bbbbb-bb",
+      "subaccount": null
+    },
+    "spender": {
+      "principal": "ccccc-cc",
+      "subaccount": null
+    },
+    "amount": 6000,
+    "fee": 5
+  }
+}
+```
+
+- At block #150, the collector is changed to `zzzzz-zz`, **and** we explicitly list `["transfer", "approve"]`.
+- From block #150 onward, **both** transfers and approves incur fees, credited to `zzzzz-zz`.
+- The **approve** operation in this same block has a fee of 5 tokens.
+
+---
+
+## 6. API for Managing Fee Collection
+
+### 6.1 Methods
+
+#### 6.1.1 `set_fee_collection`
+
+Sets or updates the fee collector account and/or the set of fee-bearing operations.
+
+**Candid Definition:**
+```candid
+set_fee_collection: (opt Account, opt vec text) -> ();
+```
+
+#### 6.1.2 `get_fee_collection`
+
+Retrieves the current fee collector account and the list of fee-bearing operations.
+
+**Candid Definition:**
+```candid
+get_fee_collection: () -> (opt Account, vec text) query;
+```
+
+---
+
+## 7. Interaction with New Standards
+
+Any new standard that introduces **additional block types** **MUST** specify how those block types interact with the fee collection mechanism defined in **ICRC-107**.
+
+---
+
+## 8. Summary
+
+- **Purely On-Chain**: Fee collection settings are managed entirely within the block history.
+- **Flexible Defaults**: Default fee-bearing operations are `["transfer"]` if not explicitly specified.
+- **Transparent Evolution**: The chain’s history defines how fee collection evolves over time, ensuring full traceability.

--- a/ICRCs/ICRC-107/ICRC-107.md.old
+++ b/ICRCs/ICRC-107/ICRC-107.md.old
@@ -1,0 +1,123 @@
+# ICRC-107: Fee Collection
+
+## 1. Introduction & Motivation
+
+Many ICRC-based ledgers (such as **ckBTC**) already implement partial fee collection, often charging fees for **transfer** transactions but not for **approve** transactions. However, there is currently no standardized way to:
+
+1. Indicate and configure **who** should collect fees (or if fees are burned).
+2. Record fee collection settings directly in ledger blocks.
+3. Provide clear semantics for wallets, explorers, and other integrations to **interpret** fee settings in a consistent way.
+
+**ICRC-107** aims to address this gap by defining:
+
+- A mechanism to specify **fee collection settings** (collector account and applicable operations) directly in blocks.
+- A **backward-compatible standard** for **recording and interpreting fee-collection fields** in ICRC-3 blocks corresponding to ICRC-1 and ICRC-2 transactions.
+- Clear rules on how fee collection settings evolve over time and how subsequent blocks rely on prior updates.
+
+This design ensures that **all** fee-related information is stored entirely **on-chain** in the block history, without reliance on external metadata or specialized block types. It provides a fully self-contained, transparent standard for fee collection that simplifies integration with wallets, explorers, and other tools.
+
+---
+
+## 2. Overview
+
+For each block, the fee amount and the account paying the fee are determined according to rules specific to the block type.
+The fee collection settings then determine if the fee is **collected** (removed from the payer account and added to a fee collector account)
+or **burned** (removed from the payer account and from the total supply):
+
+
+---
+
+## 4. Fee Collection Settings
+
+Fee collection settings determine the procedures for handling transaction fees within the ledger. These settings specify whether a fee is collected by an account or burned. When a transaction incurs a fee, the active fee collection settings at the time the block is created dictate how the fee is handled:
+
+- If a **fee collector account** (`fee_col`) is set, the fee is transferred to that account.
+- If no **fee collector account** is set, the fee is burned (removed from circulation).
+- The **operations list** (`col_ops`) defines which transaction types are subject to fee collection.
+- Changes to fee collection settings are recorded directly in blocks, ensuring an **on-chain history** of modifications.
+
+The following subsections describe the fields in blocks that manage fee collection settings and how they are used in transactions.
+
+### 4.1 Fields in Blocks
+
+A block **MAY** include the following fields to define or update fee collection settings:
+
+1. **fee_col** (optional, `Map<Value>`)
+   - `principal`: `Blob` - The principal of the fee collector.
+   - `subaccount`: `Blob` (optional) - The subaccount identifier, if applicable.
+
+2. **col_ops** (optional, `Vec<Text>`)   An array of operation types (strings) for which fees **should** be collected.   If `col_ops` is omitted, it defaults to `["transfer"]` (fee is collected for transfers only).
+
+3. **prev_fee_col_info** (optional, `Nat`)   A natural number (`Nat`) referencing the block index at which the ledger last updated `fee_col` or `col_ops`.   If present, it helps external tools quickly locate the previous fee collection settings.
+
+---
+
+## 5. Determining Fee Collection for ICRC-1 and ICRC-2 Blocks
+
+### 5.1 How to Calculate the Fee for ICRC-1 and ICRC-2 blocks
+
+The format of blocks follows the ICRC-3 standard. For a complete specification of block structure and fields, refer to [ICRC-3 Standard](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-3.md).
+
+To determine the **final fee amount** for a given block:
+
+1. **Check `tx.fee`**
+   - If present, the value of `tx.fee` is the fee for this block.
+
+2. **Else, check the top-level `fee` field**
+   - If `tx.fee` is **not set**, and a top-level field `fee` exists in the block, then that is the fee.
+
+3. **Else, fallback to `0`**
+   - If **neither** `tx.fee` nor `fee` is present, the default fee is `0`.
+
+The paying account is the source account for both transfers and approve transactions.
+
+
+### 5.2 How `col_ops` Determines Fee Collection
+
+The `col_ops` field defines which block types incur a fee that is collected (instead of burned). For ICRC-1 and ICRC-2 blocks, the mapping from a `col_ops` entry to actual block types is:
+
+| **col_ops Entry** | **Block Types Affected**                                                                                 |
+|-------------------|----------------------------------------------------------------------------------------------------------|
+| **"transfer"**    | Blocks with `btype = "1xfer"` or `btype = "2xfer"`. If `btype` is not set, then `tx.op = "xfer"` or `"2xfer"`. |
+| **"approve"**     | Blocks with `btype = "2approve"`. If `btype` is not set, then `tx.op = "approve"`.                        |
+
+**Note**: By merging the `"transfer"` and `"icrc2_transfer"` concept, any reference to `"transfer"` in `col_ops` applies to **both** ICRC-1 (`1xfer`) **and** ICRC-2 (`2xfer`) blocks.
+
+Concretely,
+
+1. **Identify Block Type**
+   - If `btype` is present, it takes precedence.
+   - Otherwise, use `tx.op`.
+
+2. **Check `col_ops`**
+   - If the block type is in `col_ops`, the fee is collected by the active `fee_col`.
+   - Otherwise, the fee is burned.
+
+If no `fee_col` is set, the fee is burned by default.
+
+---
+
+## 6. Minimal API for Fee Collection Settings
+
+### 6.1 `set_fee_collection`
+
+```
+set_fee_collection: (opt Map<Value>, opt Vec<Text>) -> ();
+```
+
+### 6.2 `get_fee_collection`
+
+```
+get_fee_collection: () -> (opt Map<Value>, Vec<Text>) query;
+```
+
+---
+
+## 7. Summary
+
+- **On-Chain Configuration**: Fee collection settings (`fee_col`, `col_ops`) are updated via blocks, with no external metadata needed.
+- **Fee Collection & Burning**: If `fee_col` is set, the fee is credited to the collector; otherwise, it is burned.
+- **Governance**: Only the **ledger controller** can update fee collection settings.
+- **Backward-Compatible**: Works seamlessly with ICRC-1, ICRC-2, and ICRC-3 block definitions.
+
+---


### PR DESCRIPTION
Many ICRC-based ledgers (such as **ckBTC**) already implement partial fee collection, often charging fees for **transfer** transactions but not for **approve** transactions. However, there is currently no standardized way to:

1. Indicate and configure **who** should collect fees (or if fees are burned).
2. Record fee collection information on existing ledgers.
3. Provide clear semantics for wallets, explorers, and other integrations to **interpret** fee information.

**ICRC-107** aims to address this gap by defining:
- A set of **metadata entries** that indicate how fees are collected.
- A **minimal interface** for setting and enabling fee collection.
- **A backward-compatible standard** for **populating and understanding fee-collection fields** in ICRC-3 blocks corresponding to ICRC-1 and ICRC-2 transactions.
- Guidance on how to **interpret fee collection fields**, as recorded in blocks, in a consistent way.