### PR TITLE
ICRC-124: blocks for recording management actions  -- stopping, unstopping and deactivating ledgers

### DIFF
--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -1,12 +1,8 @@
-## Motivation
+# ICRC-124: Ledger Pausing, Unpausing, and Deactivation
 
-ICRC-124 provides essential administrative controls for token ledgers on the Internet Computer to:
+ICRC-124 introduces new block types for recording administrative actions that control the operational state of an ICRC-compliant ledger. These blocks allow ledgers to be paused (temporarily halted), unpaused (resumed), or permanently deactivated (made immutable). This standard provides a consistent, auditable way to represent these state transitions within the ledger itself, ensuring transparency and enabling robust governance and recovery mechanisms.
 
-1. **Emergency Response**: Enable temporary suspension during security incidents or suspected fraud
-2. **Regulatory Compliance**: Support mechanisms for meeting legal requirements
-3. **Lifecycle Management**: Allow for transparent and standardized token retirement
-4. **Auditability**: Create clear records of administrative actions and their authorization
-5. **Operational Stability**: Provide standardized recovery paths from exceptional states
+
 
 
 ## Overview of Block Types

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -46,8 +46,9 @@ The recording of these blocks MUST influence the behavior of the ledger accordin
 
 ### Pause Ledger (`124pause`)
 - When a `124pause` block is recorded, the ledger MUST enter a "paused" state.
-- While paused, the ledger MUST reject all incoming requests that attempt to modify the ledger state (e.g., `icrc1_transfer`, `icrc2_approve`, `icrc122_mint`, `icrc123_freezeaccount`, etc.), **except** for requests that would result in recording a `124unpause` block.
-- Query calls SHOULD generally remain operational.
+- While paused, the ledger MUST reject incoming requests for standard token operations such as `icrc1_transfer` and `icrc2_approve`, and potentially other non-administrative state changes like `icrc122_mint` or `icrc122_burn`.
+- However, while paused, the ledger MUST continue to accept specific administrative or management operations necessary for governance or recovery. This includes operations defined in ICRC-123 (e.g., `123freezeaccount`, `123unfreezeaccount`, `123freezeprincipal`, `123unfreezeprincipal`) and, critically, requests that result in recording a `124unpause` block. The exact set of allowed administrative operations during a pause SHOULD be defined by the specific ledger implementation's policy.
+- Query calls SHOULD generally remain operational while the ledger is paused.
 
 ### Unpause Ledger (`124unpause`)
 - When a `124unpause` block is recorded, the ledger MUST exit the "paused" state and resume normal operation, accepting transactions as defined by its implementation and other active states (unless it is in a terminal state).
@@ -56,9 +57,9 @@ The recording of these blocks MUST influence the behavior of the ledger accordin
 ### Deactivate Ledger (`124deactivate`)
 - When a `124deactivate` block is recorded, the ledger MUST transition to a permanent "terminal" or "deactivated" state.
 - In this terminal state:
-    - All incoming requests that attempt to modify the ledger state MUST be permanently rejected. This includes transfers, approvals, mints, burns, freezes, pauses, unpauses, and any other state-changing operations.
-    - Query calls retrieving historical data (e.g., transaction history, past balances via `icrc3_get_blocks`) MUST remain available.
-- The deactivated state is irreversible. The ledger effectively becomes an immutable historical record.
+    - All ingress calls attempting to modify the ledger state MUST be permanently rejected. This includes, but is not limited to, transfers, approvals, mints, burns, freezes, unfreezes, pauses, unpauses, and any other state-changing operations defined now or in the future. **No transactions that alter state are permitted.**
+    - Query calls retrieving historical data (e.g., transaction history, past balances via `icrc3_get_blocks`) MUST remain available indefinitely to preserve the immutable record.
+- The deactivated state is irreversible.
 
 ## Compliance Reporting
 

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -1,0 +1,67 @@
+## Motivation
+
+ICRC-124 provides essential administrative controls for token ledgers on the Internet Computer to:
+
+1. **Emergency Response**: Enable temporary suspension during security incidents or suspected fraud
+2. **Regulatory Compliance**: Support mechanisms for meeting legal requirements
+3. **Lifecycle Management**: Allow for transparent and standardized token retirement
+4. **Auditability**: Create clear records of administrative actions and their authorization
+5. **Operational Stability**: Provide standardized recovery paths from exceptional states
+
+
+## Overview of Block Types
+
+- **Pause Ledger**: `124pause`
+- **Unpause Ledger**: `124unpause`
+- **Deactivate Ledger**: `124deactivate`
+
+## Common Structure
+
+Each block introduced by this standard MUST include a `tx` field containing a map that encodes the specific administrative action that was submitted to the ledger and which resulted in the block being created. These blocks follow the ICRC-3 structure and include:
+
+| Field    | Type (ICRC-3 `Value`) | Required | Description |
+|----------|------------------------|----------|-------------|
+| `btype`  | `Text`                 | Yes      | One of: `"124pause"`, `"124unpause"`, or `"124deactivate"` |
+| `ts`     | `Nat`                  | Yes      | Timestamp (in nanoseconds) of block creation |
+| `phash`  | `Blob`                 | Yes      | Hash of the previous block |
+| `tx`     | `Map(Text, Value)`     | Yes      | Encodes the pause, unpause, or deactivate transaction |
+
+### `tx` Field Schema
+
+All three block types share the same schema:
+
+| Field        | Type (ICRC-3 `Value`) | Required | Description |
+|--------------|------------------------|----------|-------------|
+| `authorizer` | `Blob`                 | Yes      | Principal that authorized the action |
+| `metadata`   | `Map(Text, Value)`     | Optional | Additional context (e.g., reason, governance proposal) |
+
+## Semantics
+- When a `124pause` block is recorded, the ledger MUST reject all new transactions **except** a `124unpause` transaction.
+- When a `124unpause` block is recorded, the ledger MUST resume accepting transactions (unless in terminal state).
+- When a `124deactivate` block is recorded, the ledger MUST transition to a **terminal state** where:
+  - All new state-modifying transactions are permanently rejected
+  - Historical transaction data remains available for querying
+  - The token's transaction history is preserved as an immutable record
+
+Once a `124deactivate` block is recorded, the ledger's state becomes **immutable** for transfer operations while maintaining read access to historical data.
+
+
+## Compliance Reporting
+
+Ledgers implementing this standard MUST return the following entries from `icrc3_supported_block_types`:
+
+```motoko
+vec {
+    variant { Record = vec {
+        record { "btype"; variant { Text = "124pause" }};
+        record { "url"; variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" }};
+    }};
+    variant { Record = vec {
+        record { "btype"; variant { Text = "124unpause" }};
+        record { "url"; variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" }};
+    }};
+    variant { Record = vec {
+        record { "btype"; variant { Text = "124deactivate" }};
+        record { "url"; variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" }};
+    }};
+}

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -46,6 +46,35 @@ All three block types share the same schema:
 Once a `124deactivate` block is recorded, the ledger's state becomes **immutable** for transfer operations while maintaining read access to historical data.
 
 
+## Example blocks
+
+```
+variant { Map = vec {
+    // Block type identifier
+    record { "btype"; variant { Text = "124pause" }};
+
+    // Timestamp when the block was appended (nanoseconds since epoch)
+    record { "ts"; variant { Nat = 1_741_312_737_184_874_392 : nat }};
+
+    // Hash of the previous block in the ledger chain
+    record { "phash"; variant {
+        Blob = blob "\de\ad\be\ef\00\11\22\33\44\55\66\77\88\99\aa\bb\cc\dd\ee\ff\10\20\30\40\50\60\70\80\90\a0\b0\c0"
+    }};
+
+    // Pause transaction payload
+    record { "tx"; variant { Map = vec {
+        // Principal that authorized the pause
+        record { "authorizer"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ef\01\23\45\67\89\ab\cd\ef\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f" }};
+
+        // Optional metadata
+        record { "metadata"; variant { Map = vec {
+            record { "reason"; variant { Text = "DAO vote: pause due to upgrade prep" }}
+        }}}
+    }}};
+}};
+```
+
+
 ## Compliance Reporting
 
 Ledgers implementing this standard MUST return the following entries from `icrc3_supported_block_types`:

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -55,7 +55,7 @@ variant { Map = vec {
     // Block type identifier
     record { "btype"; variant { Text = "124pause" }};
 
-    // Timestamp when the block was appended (nanoseconds since epoch)
+    // Timestamp when the block was recorded (nanoseconds since epoch)
     record { "ts"; variant { Nat = 1_741_312_737_184_874_392 : nat }};
 
     // Hash of the previous block in the ledger chain

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -48,6 +48,8 @@ Once a `124deactivate` block is recorded, the ledger's state becomes **immutable
 
 ## Example blocks
 
+### 124pause Example
+
 ```
 variant { Map = vec {
     // Block type identifier
@@ -64,7 +66,7 @@ variant { Map = vec {
     // Pause transaction payload
     record { "tx"; variant { Map = vec {
         // Principal that authorized the pause
-        record { "authorizer"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ef\01\23\45\67\89\ab\cd\ef\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f" }};
+        record { "authorizer"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ef\01\23\45\67\89\ab\cd\ef\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\01" }};
 
         // Optional metadata
         record { "metadata"; variant { Map = vec {
@@ -74,7 +76,43 @@ variant { Map = vec {
 }};
 ```
 
+### 124unpause Example
 
+```
+variant { Map = vec {
+    record { "btype"; variant { Text = "124unpause" }};
+    record { "ts"; variant { Nat = 1_741_312_737_200_000_000 : nat }};
+    record { "phash"; variant {
+        Blob = blob "\be\ba\fe\ca\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b"
+    }};
+    record { "tx"; variant { Map = vec {
+        record { "authorizer"; variant { Blob = blob "\11\22\33\44\55\66\77\88\99\aa\bb\cc\dd\ee\ff\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\01" }};
+        record { "metadata"; variant { Map = vec {
+            record { "note"; variant { Text = "Ledger resumes after maintenance window" }}
+        }}}
+    }}};
+}};
+```
+
+### 124deactivate Example
+
+```
+variant { Map = vec {
+    record { "btype"; variant { Text = "124deactivate" }};
+    record { "ts"; variant { Nat = 1_741_312_737_250_000_000 : nat }};
+    record { "phash"; variant {
+        Blob = blob "\c0\ff\ee\00\10\20\30\40\50\60\70\80\90\a0\b0\c0\d0\e0\f0\00\11\22\33\44\55\66\77\88\99\aa\bb\cc"
+    }};
+    record { "tx"; variant { Map = vec {
+        record { "authorizer"; variant { Blob = blob "\de\ad\be\ef\00\11\22\33\44\55\66\77\88\99\aa\bb\cc\dd\ee\ff\10\20\30\40\50\60\70\80\90\a0\b0\01" }};
+        record { "metadata"; variant { Map = vec {
+            record { "finalized_by"; variant { Text = "SNS DAO proposal 314" }},
+            record { "note"; variant { Text = "Ledger permanently frozen to preserve historical state" }}
+        }}}
+    }}};
+}};
+
+```
 ## Compliance Reporting
 
 Ledgers implementing this standard MUST return the following entries from `icrc3_supported_block_types`:

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -48,7 +48,7 @@ Producers MAY include fields such as:
 - `reason : Text` — human-readable context.  
 - `created_at_time : Nat` — caller-supplied timestamp (ns; MUST fit nat64).  
 - `policy_ref : Text` — identifier for proposal/vote/policy.  
-- `op : Text` — namespaced operation identifier, e.g. `148pause_ledger`.  
+- `mthd : Text` — namespaced method discriminator, e.g. `148pause_ledger`.
 
 These fields MUST NOT affect semantics or verification. Verifiers MUST ignore them.
 
@@ -80,8 +80,9 @@ These fields MUST NOT affect semantics or verification. Verifiers MUST ignore th
 
 A standard that defines ledger methods which produce ICRC-124 blocks (e.g., “pause ledger” or “deactivate ledger”) SHOULD:
 
-1. **Include `tx.op`** in the resulting block’s `tx` map.  
-   - Use a namespaced value per ICRC-3: `<icrc_number><op_name>` (e.g., `148pause_ledger`).  
+1. **Include a method discriminator** in the resulting block’s `tx` map.
+   - The recommended field name is `mthd`; alternatives (e.g., `op`) are permitted provided the choice is documented in the canonical `tx` mapping.
+   - Use a namespaced value per ICRC-3: `<icrc_number><op_name>` (e.g., `"mthd" = "148pause_ledger"`).
    - This makes the call uniquely identifiable and prevents collisions across standards.
 
 2. **Define a canonical mapping** from the method’s call parameters to the block’s minimal `tx` fields.  
@@ -188,11 +189,11 @@ variant { Map = vec {
     Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99"
   }};
   record { "tx"; variant { Map = vec {
-    record { "op"; variant { Text = "148pause_ledger" }};
+    record { "mthd"; variant { Text = "148pause_ledger" }};
     record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\03" }};
     record { "reason"; variant { Text = "DAO vote #101: emergency pause" }};
   }}};
 }};
 ```
 
-This example is non-normative and illustrates how a standardized method can map into the ICRC-124 block structure while using a namespaced `tx.op` for unambiguous identification. The authoritative semantics remain defined by the ICRC-124 block types.
+This example is non-normative and illustrates how a standardized method can map into the ICRC-124 block structure while using a namespaced method discriminator (`tx.mthd`) for unambiguous identification. The authoritative semantics remain defined by the ICRC-124 block types.

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -1,7 +1,5 @@
 # ICRC-124:  Pause, Unpause & Deactivate Blocks
 
-## Status
-
 | Status |
 |:------:|
 | Draft  |
@@ -23,7 +21,7 @@ Ledger lifecycle management may require administrative actions like pausing for 
 This standard follows the conventions set by ICRC-3, inheriting key structural components:
 
 - **Principals** are represented using the ICRC-3 `Value` type as `variant { Blob = <principal_bytes> }`.
-- **Timestamps:** `ts` (and any optional `created_at_time`) are **nanoseconds since the Unix epoch**, encoded as `Nat` but **MUST fit into `nat64`**.
+- **Timestamps:** `ts` is **nanoseconds since the Unix epoch**, encoded as `Nat` but **MUST fit into `nat64`**.
 - **Parent hash:** `phash : Blob` **MUST** be present if the block has a parent (omit for the genesis block).
 
 ## Block Types & Schema

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -2,15 +2,21 @@
 
 ## Status
 
-Draft
+| Status |
+|:------:|
+| Draft  |
+
+## Dependencies
+
+- **ICRC-3** — Provides the block log format, Value encoding, hashing, certification, and the canonical `tx` mapping rules that this standard extends.
 
 ## Introduction
 
-This standard defines new block types for recording administrative actions that control the operational state of an ICRC-compliant ledger: pausing (`124pause`), unpausing (`124unpause`), and deactivating (`124deactivate`). These actions allow ledger operations to be temporarily halted (e.g., for maintenance), resumed, or permanently stopped (making the ledger immutable). This standard provides a consistent, auditable way to represent these ledger-wide state transitions within the ledger's block history, ensuring transparency and enabling robust governance mechanisms.
+Ledger lifecycle management may require administrative actions like pausing for upgrades, unpausing after checks, or deactivating at the end of a token's useful life. ICRC-124 provides explicit block types to record these ledger-wide state transitions transparently on-chain:
 
-## Motivation
-
-Ledger lifecycle management may require administrative actions like pausing for upgrades, unpausing after checks, or deactivating at the end of a token's useful life. These significant events must be recorded transparently on-chain. This standard provides explicit block types for these actions, defining a minimal block structure sufficient for semantics, while allowing optional provenance for auditability.
+- **`124pause`** — temporarily halt all state-changing operations (e.g., for maintenance).
+- **`124unpause`** — resume normal operation after a pause.
+- **`124deactivate`** — permanently deactivate the ledger (terminal state).
 
 ## Common Elements
 
@@ -46,7 +52,7 @@ Producers MAY include fields such as:
 
 - `caller : Blob` — principal that invoked the operation.  
 - `reason : Text` — human-readable context.  
-- `created_at_time : Nat` — caller-supplied timestamp (ns; MUST fit nat64).  
+- `ts : Nat` — caller-supplied timestamp (ns; MUST fit nat64).  
 - `policy_ref : Text` — identifier for proposal/vote/policy.  
 - `mthd : Text` — namespaced method discriminator, e.g. `148pause_ledger`.
 
@@ -88,7 +94,7 @@ A standard that defines ledger methods which produce ICRC-124 blocks (e.g., “p
 2. **Define a canonical mapping** from the method’s call parameters to the block’s minimal `tx` fields.  
    - Since 124 blocks have no required fields, only provenance may be mapped.  
 
-3. **Document deduplication inputs** (if any). If the method uses a caller-supplied timestamp, put it in `tx.created_at_time`.
+3. **Document deduplication inputs** (if any). If the method uses a caller-supplied timestamp, put it in `tx.ts`.
 
 ---
 
@@ -98,9 +104,9 @@ Ledgers implementing this standard MUST return the following entries (along with
 
 ```candid
 vec {
-  record { block_type = "124pause"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" };
-  record { block_type = "124unpause"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" };
-  record { block_type = "124deactivate"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" };
+  record { block_type = "124pause";      url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124/ICRC-124.md" };
+  record { block_type = "124unpause";    url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124/ICRC-124.md" };
+  record { block_type = "124deactivate"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124/ICRC-124.md" };
 }
 ```
 
@@ -124,7 +130,7 @@ variant { Map = vec {
     // Pause transaction details
     record { "tx"; variant { Map = vec {
         // The principal that invoked the pause_ledger operation
-        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\03" }}; // Example caller principal (e.g., a governance canister)
+        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }}; // Example caller principal (e.g., a governance canister)
         // Optional reason
         record { "reason"; variant { Text = "DAO vote #78: pause for scheduled maintenance." }};
     }}};
@@ -144,7 +150,7 @@ variant { Map = vec {
     // Unpause transaction details
     record { "tx"; variant { Map = vec {
         // The principal that invoked the unpause_ledger operation
-        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\03" }}; // Example caller principal
+        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }}; // Example caller principal
         // Optional reason
         record { "reason"; variant { Text = "Ledger resumes after maintenance window (DAO vote #79)." }};
     }}};
@@ -163,7 +169,7 @@ variant { Map = vec {
     // Deactivate transaction details
     record { "tx"; variant { Map = vec {
         // The principal that invoked the deactivate_ledger operation
-        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\04" }}; // Example caller (e.g., project multisig or final DAO vote)
+        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }}; // Example caller (e.g., project multisig or final DAO vote)
         // Optional reason
         record { "reason"; variant { Text = "Token project sunset. Ledger permanently archived as per SNS DAO proposal #314." }};
     }}};
@@ -186,11 +192,11 @@ variant { Map = vec {
   record { "btype"; variant { Text = "124pause" }};
   record { "ts"; variant { Nat = 1_747_900_000_000_000_000 : nat }};
   record { "phash"; variant {
-    Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99"
+    Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99\01\23\45\67\89\ab\cd\ef\10\32\54\76\98\ba\dc\fe"
   }};
   record { "tx"; variant { Map = vec {
     record { "mthd"; variant { Text = "148pause_ledger" }};
-    record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\03" }};
+    record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }};
     record { "reason"; variant { Text = "DAO vote #101: emergency pause" }};
   }}};
 }};

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -66,6 +66,7 @@ These fields MUST NOT affect semantics or verification. Verifiers MUST ignore th
 - When a `124pause` block is recorded, the ledger MUST enter a "paused" state.
 - While paused, the ledger MUST reject all state-changing operations except those required for governance or recovery (e.g., `124unpause`, optionally `124deactivate`, and operations like freeze/unfreeze if permitted by governance policy).
 - Query calls SHOULD remain operational.
+- A `124pause` block has no effect if the ledger is already paused or if it is in a terminal state due to deactivation.
 
 ### Unpause Ledger (`124unpause`)
 - When a `124unpause` block is recorded, the ledger MUST exit the "paused" state and resume normal operation, unless it is already in the terminal state due to deactivation.

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -4,10 +4,6 @@
 |:------:|
 | Draft  |
 
-## Dependencies
-
-- **ICRC-3** — Provides the block log format, Value encoding, hashing, certification, and the canonical `tx` mapping rules that this standard extends.
-
 ## Introduction
 
 Ledger lifecycle management may require administrative actions like pausing for upgrades, unpausing after checks, or deactivating at the end of a token's useful life. ICRC-124 provides explicit block types to record these ledger-wide state transitions transparently on-chain:
@@ -15,6 +11,10 @@ Ledger lifecycle management may require administrative actions like pausing for 
 - **`124pause`** — temporarily halt all state-changing operations (e.g., for maintenance).
 - **`124unpause`** — resume normal operation after a pause.
 - **`124deactivate`** — permanently deactivate the ledger (terminal state).
+
+## Dependencies
+
+- **ICRC-3** — Provides the block log format, Value encoding, hashing, certification, and the canonical `tx` mapping rules that this standard extends.
 
 ## Common Elements
 
@@ -114,26 +114,16 @@ vec {
 
 ```candid
 variant { Map = vec {
-    // Block type identifier
     record { "btype"; variant { Text = "124pause" }};
-
-    // Timestamp when the block was recorded (nanoseconds since epoch)
-    record { "ts"; variant { Nat = 1_747_774_560_000_000_000 : nat }}; // Example: 2025-05-19T12:56:00Z
-
-    // Hash of the previous block in the ledger chain
+    record { "ts"; variant { Nat = 1_747_774_560_000_000_000 : nat }};
     record { "phash"; variant {
         Blob = blob "\de\ad\be\ef\00\11\22\33\44\55\66\77\88\99\aa\bb\cc\dd\ee\ff\10\20\30\40\50\60\70\80\90\a0\b0\c0"
     }};
-
-    // Pause transaction details
     record { "tx"; variant { Map = vec {
-        // The principal that invoked the pause_ledger operation
-        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }}; // Example caller principal (e.g., a governance canister)
-        // Optional reason
+        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }};
         record { "reason"; variant { Text = "DAO vote #78: pause for scheduled maintenance." }};
     }}};
 }};
-
 ```
 
 ### 124unpause Example
@@ -141,15 +131,12 @@ variant { Map = vec {
 ```candid
 variant { Map = vec {
     record { "btype"; variant { Text = "124unpause" }};
-    record { "ts"; variant { Nat = 1_747_778_160_000_000_000 : nat }}; // Example: 2025-05-19T13:56:00Z
+    record { "ts"; variant { Nat = 1_747_778_160_000_000_000 : nat }};
     record { "phash"; variant {
         Blob = blob "\be\ba\fe\ca\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b"
     }};
-    // Unpause transaction details
     record { "tx"; variant { Map = vec {
-        // The principal that invoked the unpause_ledger operation
-        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }}; // Example caller principal
-        // Optional reason
+        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }};
         record { "reason"; variant { Text = "Ledger resumes after maintenance window (DAO vote #79)." }};
     }}};
 }};
@@ -160,19 +147,15 @@ variant { Map = vec {
 ```candid
 variant { Map = vec {
     record { "btype"; variant { Text = "124deactivate" }};
-    record { "ts"; variant { Nat = 1_747_864_560_000_000_000 : nat }}; // Example: 2025-05-20T12:56:00Z
+    record { "ts"; variant { Nat = 1_747_864_560_000_000_000 : nat }};
     record { "phash"; variant {
         Blob = blob "\c0\ff\ee\00\10\20\30\40\50\60\70\80\90\a0\b0\c0\d0\e0\f0\00\11\22\33\44\55\66\77\88\99\aa\bb\cc"
     }};
-    // Deactivate transaction details
     record { "tx"; variant { Map = vec {
-        // The principal that invoked the deactivate_ledger operation
-        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }}; // Example caller (e.g., project multisig or final DAO vote)
-        // Optional reason
+        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }};
         record { "reason"; variant { Text = "Token project sunset. Ledger permanently archived as per SNS DAO proposal #314." }};
     }}};
 }};
-
 ```
 
 ### Informative Example: Integration with a Standardized Method

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -1,4 +1,4 @@
-# ICRC-124: Ledger Pausing, Unpausing, and Deactivation
+# ICRC-124:  Pause, Unpause & Deactivate Blocks
 
 ## Status
 

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -79,6 +79,13 @@ These fields MUST NOT affect semantics or verification. Verifiers MUST ignore th
   - Query calls retrieving historical data MUST remain available.
 - The deactivated state is irreversible.
 
+### Querying Ledger State
+
+Ledgers implementing this standard SHOULD expose queries (e.g., `is_paused() : bool`,
+`is_deactivated() : bool`) that return the ledger's current operational state
+per the rules above. These are a convenience and do not replace auditing from
+history. See **ICRC-154** for a standardized API.
+
 ---
 
 ## Guidance for Standards That Define Methods

--- a/ICRCs/ICRC-124/ICRC-124.md
+++ b/ICRCs/ICRC-124/ICRC-124.md
@@ -6,83 +6,101 @@ Draft
 
 ## Introduction
 
-This standard defines new block types for recording administrative actions that control the operational state of an ICRC-compliant ledger: pausing (`124pause`), unpausing (`124unpause`), and deactivating (`124deactivate`). These actions allow ledger operations to be temporarily halted (e.g., for maintenance), resumed, or permanently stopped (making the ledger immutable). This standard provides a consistent, auditable way to represent these ledger-wide state transitions within the ledger's block history, ensuring transparency and enabling robust governance mechanisms. The transaction details (`tx`) within each block explicitly include the `caller` principal that authorized the operation.
+This standard defines new block types for recording administrative actions that control the operational state of an ICRC-compliant ledger: pausing (`124pause`), unpausing (`124unpause`), and deactivating (`124deactivate`). These actions allow ledger operations to be temporarily halted (e.g., for maintenance), resumed, or permanently stopped (making the ledger immutable). This standard provides a consistent, auditable way to represent these ledger-wide state transitions within the ledger's block history, ensuring transparency and enabling robust governance mechanisms.
 
 ## Motivation
 
-Ledger lifecycle management may require administrative actions like pausing for upgrades, unpausing after checks, or deactivating at the end of a token's useful life. These significant events must be recorded transparently on-chain. This standard provides explicit block types for these actions, defining a block structure that includes the initiator (`caller`) and essential details for the operation, enhancing on-chain auditability.
+Ledger lifecycle management may require administrative actions like pausing for upgrades, unpausing after checks, or deactivating at the end of a token's useful life. These significant events must be recorded transparently on-chain. This standard provides explicit block types for these actions, defining a minimal block structure sufficient for semantics, while allowing optional provenance for auditability.
 
 ## Common Elements
-This standard follows the conventions set by ICRC-3, inheriting key structural components.
-- **Principals** (such as the `caller`) are represented using the ICRC-3 `Value` type as `variant { Blob = <principal_bytes> }`.
-- Each block includes `phash`, a `Blob` representing the hash of the parent block, and `ts`, a `Nat` representing the timestamp of the block.
+
+This standard follows the conventions set by ICRC-3, inheriting key structural components:
+
+- **Principals** are represented using the ICRC-3 `Value` type as `variant { Blob = <principal_bytes> }`.
+- **Timestamps:** `ts` (and any optional `created_at_time`) are **nanoseconds since the Unix epoch**, encoded as `Nat` but **MUST fit into `nat64`**.
+- **Parent hash:** `phash : Blob` **MUST** be present if the block has a parent (omit for the genesis block).
 
 ## Block Types & Schema
 
-Each block introduced by this standard MUST include a `tx` field containing a map. This map encodes information about the administrative action, including the `caller` principal and an optional reason.
+Each block introduced by this standard MUST include a `tx` field containing a map. This map encodes the **minimal information** about the ledger state change. Additional provenance MAY be included but is not required for semantics.
 
-**Important Note on Transaction Recoverability:** The `tx` field defined below now includes the `caller` principal. However, for full auditability and transparency in complex scenarios, ledger implementations compliant with ICRC-124 **MUST** ensure that any other details of the original transaction invocation not captured in `tx` can be recovered independently. This could include, but is not limited to, the full arguments passed to the ledger method (if more complex than the data in `tx`), or any intermediary calls if the operation was part of a multi-step process. Mechanisms for recovering such extended data (e.g., via archive queries or specific lookup methods) remain implementation-dependent. The rules determining *who* is authorized to invoke these ledger state change operations are an implementation detail of the ledger's governance model.
+Each block consists of the following top-level fields:
 
-Each block defined by this standard consists of the following top-level fields:
+| Field | Type (ICRC-3 `Value`) | Required | Description |
+|-------|------------------------|----------|-------------|
+| `btype` | `Text` | Yes | MUST be one of: `"124pause"`, `"124unpause"`, or `"124deactivate"`. |
+| `ts` | `Nat` | Yes | Timestamp (ns since Unix epoch) when the block was added to the ledger. MUST fit in `nat64`. |
+| `phash` | `Blob` | Yes/No | Hash of the parent block; omitted only for the genesis block. |
+| `tx` | `Map(Text, Value)` | Yes | Minimal operation details (see below). |
 
-| Field    | Type (ICRC-3 `Value`) | Required | Description |
-|----------|------------------------|----------|-------------|
-| `btype`  | `Text`                 | Yes      | MUST be one of: `"124pause"`, `"124unpause"`, or `"124deactivate"`. |
-| `ts`     | `Nat`                  | Yes      | Timestamp in nanoseconds when the block was added to the ledger. |
-| `phash`  | `Blob`                 | Yes      | Hash of the parent block. |
-| `tx`     | `Map(Text, Value)`     | Yes      | Encodes information about the pause/unpause/deactivate operation, including the caller. See schema below. |
+### `tx` Field Schema (minimal)
 
-### `tx` Field Schema
+For all `124pause`, `124unpause`, and `124deactivate` blocks:
 
-The `tx` field schema is the same for `124pause`, `124unpause`, and `124deactivate`:
+- No required fields are needed for semantics.  
+- The presence of the block type alone (`btype`) determines the state transition.  
 
-| Field        | Type (ICRC-3 `Value`)                                    | Required | Description |
-|--------------|----------------------------------------------------------|----------|-------------|
-| `caller`     | `Value` (Must be `variant { Blob = <principal_bytes> }`)     | Yes      | The principal that invoked the ledger method causing this block. |
-| `reason`     | `Text`                                                   | Optional | Human-readable reason for the administrative action. |
+### Optional Provenance (non-semantic)
+
+Producers MAY include fields such as:
+
+- `caller : Blob` — principal that invoked the operation.  
+- `reason : Text` — human-readable context.  
+- `created_at_time : Nat` — caller-supplied timestamp (ns; MUST fit nat64).  
+- `policy_ref : Text` — identifier for proposal/vote/policy.  
+- `op : Text` — namespaced operation identifier, e.g. `148pause_ledger`.  
+
+These fields MUST NOT affect semantics or verification. Verifiers MUST ignore them.
+
+> **Informative note (recoverability):** Implementations **SHOULD** provide mechanisms (e.g., archives or lookups) to retrieve extended invocation context not present in `tx` when useful for audits. The authorization model that permits these actions is implementation-defined.
+
+---
 
 ## Semantics
 
-The recording of these blocks MUST influence the behavior of the ledger according to the following semantics:
-
 ### Pause Ledger (`124pause`)
 - When a `124pause` block is recorded, the ledger MUST enter a "paused" state.
-- While paused, the ledger MUST reject incoming requests for standard token operations such as `icrc1_transfer`, `icrc2_approve`, and other non-administrative state changes such as those defined in ICRC-122 (e.g., `122mint`, `122burn`).
-- However, while paused, the ledger MUST continue to accept specific administrative or management operations necessary for governance or recovery. This includes operations defined in ICRC-123 (e.g., `123freezeaccount`, `123unfreezeaccount`, `123freezeprincipal`, `123unfreezeprincipal`) and, critically, requests that result in recording a `124unpause` block. Ledger implementations MAY also permit requests that result in recording a `124deactivate` block while the ledger is paused, according to their defined governance policies. The exact set of allowed administrative operations during a pause SHOULD be defined by the specific ledger implementation's policy.
-- Query calls SHOULD generally remain operational while the ledger is paused.
+- While paused, the ledger MUST reject all state-changing operations except those required for governance or recovery (e.g., `124unpause`, optionally `124deactivate`, and operations like freeze/unfreeze if permitted by governance policy).
+- Query calls SHOULD remain operational.
 
 ### Unpause Ledger (`124unpause`)
-- When a `124unpause` block is recorded, the ledger MUST exit the "paused" state and resume normal operation, accepting transactions as defined by its implementation and other active states (unless it is in a terminal state).
-- An `124unpause` block has no effect if the ledger is already unpaused or if it is in a terminal state due to deactivation.
+- When a `124unpause` block is recorded, the ledger MUST exit the "paused" state and resume normal operation, unless it is already in the terminal state due to deactivation.
+- An `124unpause` block has no effect if the ledger is already unpaused or deactivated.
 
 ### Deactivate Ledger (`124deactivate`)
-- When a `124deactivate` block is recorded, the ledger MUST transition to a permanent "terminal" or "deactivated" state.
-- In this terminal state:
-    - All ingress calls attempting to modify the ledger state MUST be permanently rejected. This includes, but is not limited to, transfers, approvals, mints, burns, freezes, unfreezes, pauses, unpauses, and any other state-changing operations defined now or in the future. **No transactions that alter state are permitted.**
-    - Query calls retrieving historical data (e.g., transaction history, past balances via `icrc3_get_blocks`) MUST remain available indefinitely to preserve the immutable record.
+- When a `124deactivate` block is recorded, the ledger MUST transition to a permanent "terminal" state.
+- In this state:
+  - All ingress calls that modify state MUST be rejected (transfers, approvals, mints, burns, freezes, pauses, unpauses, etc.).
+  - Query calls retrieving historical data MUST remain available.
 - The deactivated state is irreversible.
+
+---
+
+## Guidance for Standards That Define Methods
+
+A standard that defines ledger methods which produce ICRC-124 blocks (e.g., “pause ledger” or “deactivate ledger”) SHOULD:
+
+1. **Include `tx.op`** in the resulting block’s `tx` map.  
+   - Use a namespaced value per ICRC-3: `<icrc_number><op_name>` (e.g., `148pause_ledger`).  
+   - This makes the call uniquely identifiable and prevents collisions across standards.
+
+2. **Define a canonical mapping** from the method’s call parameters to the block’s minimal `tx` fields.  
+   - Since 124 blocks have no required fields, only provenance may be mapped.  
+
+3. **Document deduplication inputs** (if any). If the method uses a caller-supplied timestamp, put it in `tx.created_at_time`.
+
+---
 
 ## Compliance Reporting
 
-Ledgers implementing this standard MUST return the following entries (including entries for other supported types like ICRC-1, ICRC-3, etc.) from `icrc3_supported_block_types`, with URLs pointing to the standards defining each block type:
+Ledgers implementing this standard MUST return the following entries (along with entries for other supported block types) from `icrc3_supported_block_types`:
 
 ```candid
 vec {
-    // ... other supported types like ICRC-1, ICRC-3, ICRC-122, ICRC-123 ...
-    variant { Record = vec {
-        record { "btype"; variant { Text = "124pause" }};
-        record { "url"; variant { Text = "[https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md)" }}; // Placeholder URL
-    }};
-    variant { Record = vec {
-        record { "btype"; variant { Text = "124unpause" }};
-        record { "url"; variant { Text = "[https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md)" }}; // Placeholder URL
-    }};
-    variant { Record = vec {
-        record { "btype"; variant { Text = "124deactivate" }};
-        record { "url"; variant { Text = "[https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md)" }}; // Placeholder URL
-    }};
+  record { block_type = "124pause"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" };
+  record { block_type = "124unpause"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" };
+  record { block_type = "124deactivate"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-124.md" };
 }
-
 ```
 
 ## Example Blocks
@@ -151,3 +169,30 @@ variant { Map = vec {
 }};
 
 ```
+
+### Informative Example: Integration with a Standardized Method
+ICRC-124 defines only block types and their semantics. It does not define any ledger methods.
+However, future standards may specify methods that map directly to these block types.
+
+For illustration, suppose a future standard (e.g., ICRC-148) introduces the method:
+```
+icrc148_pause_ledger : (opt text) -> result nat
+```
+
+Invoking this method with an optional reason could produce a `124pause` block:
+```
+variant { Map = vec {
+  record { "btype"; variant { Text = "124pause" }};
+  record { "ts"; variant { Nat = 1_747_900_000_000_000_000 : nat }};
+  record { "phash"; variant {
+    Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99"
+  }};
+  record { "tx"; variant { Map = vec {
+    record { "op"; variant { Text = "148pause_ledger" }};
+    record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\03" }};
+    record { "reason"; variant { Text = "DAO vote #101: emergency pause" }};
+  }}};
+}};
+```
+
+This example is non-normative and illustrates how a standardized method can map into the ICRC-124 block structure while using a namespaced `tx.op` for unambiguous identification. The authoritative semantics remain defined by the ICRC-124 block types.


### PR DESCRIPTION
Real World Asset ledgers require several management APIs that would allow authorised entities to carry out ledger changes. This standard introduces three new blocktypes:


- block type `123pause` that records that all transactions on the ledger were paused by an authorised party
- block type `123unpause` that records that a paused ledger was unpause by an authorised party
- block type `123deactivate` that records that a ledger was deactivated by an authorised party