### PR TITLE
align icrc-103 standard with implementation deployed in production

### DIFF
--- a/ICRCs/ICRC-103/ICRC-103.md
+++ b/ICRCs/ICRC-103/ICRC-103.md
@@ -44,7 +44,7 @@ type GetAllowancesArgs = record {
 }
 
 type GetAllowancesError = variant{
-    AccessDenied : text;
+    AccessDenied: record { reason: text };
     GenericError : record { error_code : nat; message : text };
 }
 


### PR DESCRIPTION
The current implementation rolled out in production on ck tokens has diverged from standard. This PR aligns the two by changing the spec