### PR TITLE
ICRC-152: Standardizing Privileged Mint & Burn

### DIFF
--- a/ICRCs/ICRC-152/ICRC-152.did
+++ b/ICRCs/ICRC-152/ICRC-152.did
@@ -1,0 +1,44 @@
+type Account = record {
+  owner      : principal;
+  subaccount : opt blob;
+};
+
+type MintArgs = record {
+  to              : Account;
+  amount          : nat;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type MintError = variant {
+  Unauthorized        : text;
+  InvalidAccount      : text;
+  InvalidAmount       : text;
+  TooOld;
+  CreatedInFuture     : record { ledger_time : nat64 };
+  Duplicate           : record { duplicate_of : nat };
+  GenericError        : record { error_code : nat; message : text };
+};
+
+type BurnArgs = record {
+  from            : Account;
+  amount          : nat;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type BurnError = variant {
+  Unauthorized        : text;
+  InvalidAccount      : text;
+  InvalidAmount       : text;
+  InsufficientBalance : record { balance : nat };
+  TooOld;
+  CreatedInFuture     : record { ledger_time : nat64 };
+  Duplicate           : record { duplicate_of : nat };
+  GenericError        : record { error_code : nat; message : text };
+};
+
+service : {
+  icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
+  icrc152_burn : (BurnArgs) -> (variant { Ok : nat; Err : BurnError });
+};

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -4,91 +4,223 @@
 |:------:|
 | Draft  |
 
-`ICRC‑152` defines privileged minting and burning operations for ICRC‑compliant ledgers. It specifies two methods—`icrc152_mint` and `icrc152_burn`—and describes the canonical block representation of each call according to `ICRC‑3`. The methods map to `122mint` and `122burn` block types, while the `tx.op` field is namespaced with `152`. Each `tx` also records the caller’s principal and an optional human‑readable reason.
+## Introduction & Motivation
+
+Most ICRC-based ledgers (e.g., ICRC-1, ICRC-2) treat minting and burning as
+system-only operations that occur indirectly.
+
+- Minting is represented as a transfer from the minting account.
+- Burning is represented as a transfer into the minting account.
+
+This approach works for decentralized tokens but is insufficient for
+administrator-controlled or regulated assets, such as:
+
+- Stablecoins, which must allow an issuer to adjust circulating supply.
+- Real-World Asset (RWA) tokens, where compliance requires explicit
+  mint and burn actions.
+- Other managed ledgers (NFTs, reward points, internal credits).
+
+Without a standardized API, integrators and tooling cannot reliably
+distinguish user-initiated supply changes from privileged supply
+management actions.
+
+ICRC-152 addresses this gap by introducing:
+
+- Two privileged methods, `icrc152_mint` and `icrc152_burn`, callable only by authorized principals.
+- A canonical mapping from method inputs to block `tx` fields, including optional metadata and caller tracking.
+- Recording of these operations using the typed block kinds **defined in ICRC-122**:
+  `btype = "122mint"` for mints and `btype = "122burn"` for burns.
+
+
+## Overview
+
+ICRC-152 standardizes privileged supply management in ICRC-based ledgers.
+
+Specifically, it defines:
+
+- **APIs** for minting and burning tokens under ledger authorization.
+- **Canonical `tx` mapping** rules ensuring deterministic block content.
+- **Use of ICRC-122 block kinds** to record privileged supply actions
+  (`btype = "122mint"` and `btype = "122burn"`).
+- **Compliance reporting** through ICRC-10 methods.
+  
+
+
+This allows wallets, explorers, and auditors to:
+
+- Reliably distinguish privileged supply changes from user-initiated transfers.
+- Verify compliance with external requirements (e.g., MiCA).
+- Interoperate across ledgers that adopt the same API and block semantics.
+
+
+## Dependencies
+
+This standard does not introduce new block kinds.
+
+- **ICRC-3** — Provides the block log format, hashing, certification, and rules
+  for canonical `tx` mapping.
+- **ICRC-122** — Defines the typed block kinds used by this standard:
+  - `btype = "122mint"` (authorized mint block)
+  - `btype = "122burn"` (authorized burn block)
+
+A ledger implementing ICRC-152 MUST:
+- Emit `122mint` for successful `icrc152_mint` calls and `122burn` for successful
+  `icrc152_burn` calls.
+- Populate `tx.op` with namespaced values **introduced by this standard**:
+  `"152mint"` and `"152burn"`.
 
 
 
-## Type Definitions
 
 
+## Methods
+
+### `icrc152_mint`
+
+
+This method allows a ledger controller (or other authorized principal) to mint
+tokens. It credits the specified account, increases total supply, and records
+the action on-chain.
+
+
+#### Arguments
 ```
 type MintArgs = record {
-  to              : Account;    // target account receiving the minted tokens
-  amount          : nat;        // number of tokens to mint
-  created_at_time : nat64;      // timestamp in nanoseconds since Unix epoch
-  reason          : opt text;   // optional human-readable reason for the mint
-};
-
-type BurnArgs = record {
-  from            : Account;    // account from which tokens are burned
-  amount          : nat;        // number of tokens to burn
-  created_at_time : nat64;      // timestamp in nanoseconds since Unix epoch
-  reason          : opt text;   // optional human-readable reason for the burn
+  to              : Account;
+  amount          : nat;
+  created_at_time : nat64;
+  reason          : opt text;
 };
 
 type MintError = variant {
-  Unauthorized;
-  InvalidAccount;
-  CreatedInFuture;
-  Duplicate;
-  TemporarilyUnavailable;
-  Other : text;
+    Unauthorized : text;              // caller not permitted
+    InvalidAccount : text;             // target account invalid
+    Duplicate : record { duplicate_of : nat }; 
+    GenericError : record { error_code : nat; message : text };
+};
+
+icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
+```
+
+
+#### Semantics
+- **Credits** `amount` tokens to the `to` account.  
+- **Increases** the total supply by `amount`.  
+- **Creates** a block of type `122mint`.  
+- On success, returns the **index of the created block**.  
+- On failure, returns an appropriate error.  
+- Semantics are consistent with the core transition already defined for `122mint` blocks.  
+
+#### Return Values
+On success, the method returns
+
+- `variant { Ok : nat }`  
+  where the `nat` is the index of the block created in the ledger.  
+
+On failure, the method returns
+
+- `variant { Err : MintError }`  
+  describing the reason for rejection.  
+
+
+
+#### Canonical `tx` Mapping
+A successful call to `icrc152_mint` produces a block of type `122mint`.  
+The `tx` field is derived deterministically as follows:
+
+- `op     = "152mint"`  
+- `to     = MintArgs.to`  
+- `amt    = MintArgs.amount`  
+- `ts     = MintArgs.created_at_time`  
+- `caller = caller_principal (as Blob)`  
+- `reason = MintArgs.reason` (if provided)  
+
+Optional fields (`reason`) MUST be omitted from `tx` if not supplied in the call.  
+
+
+
+### `icrc152_burn`
+
+This method allows a ledger controller (or other authorized principal) to burn
+tokens. It debits the specified account, decreases total supply, and records
+the action on-chain.
+
+```
+type BurnArgs = record {
+  from            : Account;
+  amount          : nat;
+  created_at_time : nat64;
+  reason          : opt text;
 };
 
 type BurnError = variant {
-  Unauthorized;
-  InsufficientBalance;
-  InvalidAccount;
-  CreatedInFuture;
-  Duplicate;
-  TemporarilyUnavailable;
-  Other : text;
+  Unauthorized : text;              // caller not permitted
+  InvalidAccount : text;             // source account invalid
+  InsufficientBalance : record { balance : nat };
+  Duplicate : record { duplicate_of : nat }; 
+  GenericError : record { error_code : nat; message : text };
 };
-```
-
-
-## Method Signatures
-
-```
-icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
 
 icrc152_burn : (BurnArgs) -> (variant { Ok : nat; Err : BurnError });
 ```
 
-## Semantics
 
-- **Authorisation:** The ledger MUST verify that the caller is authorised to mint or burn. If not, it returns `Err.Unauthorized`.
-- **Supply update:**  
-  - For `icrc152_mint`, increase the total supply by `amount` and credit `amount` to the `to` account.  
-  - For `icrc152_burn`, decrease the total supply by `amount` and debit `amount` from the `from` account. If the `from` account does not hold enough tokens, the ledger MUST return `Err.InsufficientBalance`.
-- **Fees:** Neither operation charges a fee under this specification.
-- **Return value:** On success, return the index of the newly appended block as `Ok(nat)`.
-- **Caller field:** The `caller` field in the `tx` record MUST contain the principal of the caller encoded as a blob. This field is informational and does not affect the state transition.
+#### Semantics
+- **Debits** `amount` tokens from the `from` account.  
+- **Decreases** the total supply by `amount`.  
+- **Creates** a block of type `122burn`.  
+- On success, returns the **index of the created block**.  
+- On failure, returns an appropriate error.  
+- Semantics are consistent with the core transition already defined for `122burn` blocks.  
+
+#### Return Values
+On success, the method returns
+
+- `variant { Ok : nat }`  
+  where the `nat` is the index of the block created in the ledger.  
+
+On failure, the method returns
+
+- `variant { Err : BurnError }`  
+  describing the reason for rejection.  
 
 
-## Canonical `tx` Mapping for Successful Calls
+#### Canonical `tx` Mapping
+A successful call to `icrc152_burn` produces a block of type `122burn`.  
+The `tx` field is derived deterministically as follows:
 
-### Mint block (btype = "122mint")
+- `op     = "152burn"`  
+- `from   = BurnArgs.from`  
+- `amt    = BurnArgs.amount`  
+- `ts     = BurnArgs.created_at_time`  
+- `caller = caller_principal (as Blob)`  
+- `reason = BurnArgs.reason` (if provided)  
+
+Optional fields (`reason`) MUST be omitted from `tx` if not supplied in the call.  
+
+### Reporting Compliance
+
+#### Supported Standards
+
+Ledgers implementing ICRC-152 MUST indicate compliance through the
+`icrc1_supported_standards` and `icrc10_supported_standards` methods, by
+including in the output of these methods:
 
 ```
-tx.op     = "152mint"
-tx.to     = MintArgs.to
-tx.amt    = MintArgs.amount
-tx.ts     = MintArgs.created_at_time
-tx.caller = caller_principal (as Blob)
-tx.reason = MintArgs.reason (if provided)
+variant { Vec = vec {
+    record {
+        "name"; variant { Text = "ICRC-152" };
+        "url";  variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-152.md" };
+    }
+}};
 ```
 
-### Burn block (btype = "122burn")
-```
-tx.op     = "152burn"
-tx.from   = BurnArgs.from
-tx.amt    = BurnArgs.amount
-tx.ts     = BurnArgs.created_at_time
-tx.caller = caller_principal (as Blob)
-tx.reason = BurnArgs.reason (if provided)
-```
+#### Supported Block Types
 
+ICRC-152 extends ICRC-122 and does not introduce any new block kinds.
+Accordingly, ledgers implementing ICRC-152 MUST already advertise support
+for `122mint` and `122burn` as required by ICRC-122.
+No additional block types need to be reported.
 
 ### Example mint call and resulting block
 
@@ -144,7 +276,18 @@ variant {
 
 ```
 
-The block records the operation (`op = "152mint"`), the recipient account (`to`), the minted amount (`amt`), the timestamp supplied by the caller (`ts`), the caller’s principal (`caller`) and the optional `reason`.
+
+
+The block records the operation (`op = "152mint"`), the recipient account (`to`), 
+the minted amount (`amt`), the timestamp supplied by the caller (`ts`), the caller’s 
+principal (`caller`), and the optional `reason`.  
+
+In the method call example above, the recipient is shown as a human-readable 
+principal literal. In the resulting block, the same principal is encoded canonically 
+as `variant { Blob = ... }`, where the `Blob` contains the raw byte representation 
+of the principal as defined by ICRC-3. Both forms represent the same identity; 
+the difference is only in presentation.  
+
 
 ### Example burn call and resulting block
 
@@ -159,7 +302,7 @@ icrc152_burn({
 })
 
 ```
-Here, `from` s the account to be debited,, `amount` is the number of tokens to burn, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
+Here, `from` is the account to be debited, `amount` is the number of tokens to burn, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
 
 #### Resulting block
 
@@ -185,8 +328,7 @@ variant {
             "from";
             variant {
               Array = vec {
-                variant { Blob = blob  
-                "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" }
+                variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" }
               }
             };
           };
@@ -203,6 +345,11 @@ variant {
 
 ```
 
-Here, the block records the operation (`op = "152burn"`), the account being debited (`from`), the burned amount (`amt`), the caller‑provided timestamp (`ts`), the caller’s principal (`caller`) and the optional `reason`. 
+Here, the block records the operation (`op = "152burn"`), the account being debited (`from`), 
+the burned amount (`amt`), the caller-provided timestamp (`ts`), the caller’s principal (`caller`), 
+and the optional `reason`.  
 
+In the method call example, the account is shown as a principal literal. In the resulting block, 
+the same principal is encoded canonically as `variant { Blob = ... }`. These two forms 
+represent the same identity; the difference is only in presentation.  
 

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -70,6 +70,26 @@ A ledger implementing ICRC-152 MUST:
   `"152mint"` and `"152burn"`.
 
 
+## Common Elements
+
+This standard inherits core conventions from **ICRC-3** (block log format, Value encoding, hashing, certification) and **ICRC-122** (typed block kinds).
+
+- **Accounts**  
+  Encoded as ICRC-3 `Value` `variant { Array = vec { V1 [, V2] } }` where  
+  `V1 = variant { Blob = <owner_principal_bytes> }` and optionally  
+  `V2 = variant { Blob = <32-byte_subaccount_bytes> }`.  
+  If no subaccount is provided, the array contains only the owner principal.
+
+- **Principals**  
+  Encoded as `variant { Blob = <principal_bytes> }`.
+
+- **Timestamps**  
+  Caller-supplied `created_at_time` is in **nanoseconds since Unix epoch**.  
+  Encoded as `Nat` in ICRC-3 `Value` and **MUST** fit in `nat64`.
+
+- **Blocks & Parent Hash**  
+  Resulting blocks for these APIs use `btype = "122mint"` and `btype = "122burn"` (per ICRC-122).  
+  Standard metadata (e.g., `phash`, `ts`) follows ICRC-3.
 
 
 
@@ -104,38 +124,51 @@ icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
 
 
 #### Semantics
-- **Credits** `amount` tokens to the `to` account.  
-- **Increases** the total supply by `amount`.  
-- **Creates** a block of type `122mint`.  
-- On success, returns the **index of the created block**.  
-- On failure, returns an appropriate error.  
-- Semantics are consistent with the core transition already defined for `122mint` blocks.  
 
-#### Return Values
-On success, the method returns
+**Authorization**  
+- The method **MUST** be callable only by a **controller** of the ledger or other explicitly authorized principals.  
+- Unauthorized calls **MUST** fail with `Unauthorized`.
 
-- `variant { Ok : nat }`  
-  where the `nat` is the index of the block created in the ledger.  
+**Effect (on success, non-retroactive)**  
+- **Credit** `amount` to `to`.  
+- **Increase** total supply by `amount`.  
+- **Append** a block with `btype = "122mint"`.  
+- The block’s top-level `tx` **MUST** be constructed **exactly** as in **Canonical `tx` Mapping** (keys, types, encodings), and embedded in the block.
 
-On failure, the method returns
+**Return value**  
+- On success, **MUST** return `variant { Ok : nat }` where the `nat` is the index of the created block.  
+- On failure, **MUST** return `variant { Err : MintError }`.
 
-- `variant { Err : MintError }`  
-  describing the reason for rejection.  
+**Deduplication & idempotency**  
+- The ledger **MUST** perform deduplication (e.g., using `created_at_time` and any implementation-defined inputs).  
+- If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
+**Error cases (normative)**  
+- `Unauthorized` — caller not permitted.  
+- `InvalidAccount` — malformed/invalid target account (e.g., minting account, anonymous principal, invalid subaccount bytes).  
+- `Duplicate { duplicate_of }` — a semantically identical transaction was already accepted.  
+- `GenericError { error_code, message }` — any other failure preventing a valid `122mint` block.
+
+**Clarifications**  
+- Optional fields **MUST be omitted** from `tx` if not supplied in the call (no null placeholders).  
+- Representation-independent hashing (ICRC-3) applies; field presence and values matter, not map ordering.
 
 
 #### Canonical `tx` Mapping
 A successful call to `icrc152_mint` produces a block of type `122mint`.  
 The `tx` field is derived deterministically as follows:
 
-- `op     = "152mint"`  
-- `to     = MintArgs.to`  
-- `amt    = MintArgs.amount`  
-- `ts     = MintArgs.created_at_time`  
-- `caller = caller_principal (as Blob)`  
-- `reason = MintArgs.reason` (if provided)  
+#### Canonical `tx` Mapping (normative)
 
-Optional fields (`reason`) MUST be omitted from `tx` if not supplied in the call.  
+| Field             | Type (ICRC-3 `Value`) | Source / Encoding Rule                                                     |
+|-------------------|------------------------|-----------------------------------------------------------------------------|
+| `op`              | `Text`                 | **Constant** `"152mint"`.                                                  |
+| `to`              | `Array` (Account)      | From `MintArgs.to`, encoded as ICRC-3 Account.                             |
+| `amt`             | `Nat`                  | From `MintArgs.amount`.                                                    |
+| `created_at_time` | `Nat`                  | From `MintArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
+| `caller`          | `Blob`                 | Principal of the caller (raw bytes).                                       |
+| `reason`          | `Text` *(optional)*    | From `MintArgs.reason` if provided; **omit** if absent.                    |
+
 
 
 

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -154,11 +154,9 @@ icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
 - Representation-independent hashing (ICRC-3) applies; field presence and values matter, not map ordering.
 
 
-#### Canonical `tx` Mapping
-A successful call to `icrc152_mint` produces a block of type `122mint`.  
-The `tx` field is derived deterministically as follows:
-
 #### Canonical `tx` Mapping (normative)
+A successful call to `icrc152_mint` produces a block of type `122mint`.
+The `tx` field is derived deterministically as follows:
 
 | Field             | Type (ICRC-3 `Value`) | Source / Encoding Rule                                                     |
 |-------------------|------------------------|-----------------------------------------------------------------------------|
@@ -240,12 +238,12 @@ Ledgers implementing ICRC-152 MUST indicate compliance through the
 including in the output of these methods:
 
 ```
-variant { Vec = vec {
+vec {
     record {
-        "name"; variant { Text = "ICRC-152" };
-        "url";  variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-152.md" };
+        name = "ICRC-152";
+        url  = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-152/ICRC-152.md";
     }
-}};
+}
 ```
 
 #### Supported Block Types
@@ -261,13 +259,13 @@ No additional block types need to be reported.
 The caller invokes
 ```
 icrc152_mint({
-  to              = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
+  to              = record { owner = principal "ryjl3-tyaaa-aaaaa-aaaba-cai"; subaccount = null };
   amount          = 500_000;
   created_at_time = 1_753_344_737_123_456_789 : nat64;
-  reason          = ?"Initial allocation";
+  reason          = opt "Initial allocation";
 })
 ```
-Here, `to` is the account of the recipient, `amount` is the number of tokens to mint, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
+Here, `to` is the Candid `Account` of the recipient (with `owner` as a principal and an optional `subaccount`), `amount` is the number of tokens to mint, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
 
 #### Resulting block
 
@@ -283,7 +281,7 @@ variant {
         Blob = blob "\a0\5f\d2\f3\4c\26\73\58\00\7f\ea\02\18\43\47\70\85\50\2e\d2\1f\23\e0\dc\e6\af\3c\cf\9e\6f\4a\d8"
       };
     };
-    record { "ts"; variant { Nat64 = 1_753_344_738_000_000_000 : nat64 } };
+    record { "ts"; variant { Nat = 1_753_344_738_000_000_000 } };
     record {
       "tx";
       variant {
@@ -293,12 +291,12 @@ variant {
             "to";
             variant {
               Array = vec {
-                variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
+                variant { Blob = blob "\d3\e2\95\d8\63\bc\ef\0d\02" }
               }
             };
           };
-          record { "amt";    variant { Nat64 = 500_000 : nat64 } };
-          record { "ts";     variant { Nat64 = 1_753_344_737_123_456_789 : nat64 } };
+          record { "amt";    variant { Nat = 500_000 } };
+          record { "ts";     variant { Nat = 1_753_344_737_123_456_789 } };
           record { "caller"; variant { Blob  = blob "\00\00\00\00\02\30\02\17\01\01" } };
           record { "reason"; variant { Text  = "Initial allocation" } };
         }
@@ -315,11 +313,9 @@ The block records the method (`mthd = "152mint"`), the recipient account (`to`),
 the minted amount (`amt`), the timestamp supplied by the caller (`ts`), the caller’s 
 principal (`caller`), and the optional `reason`.  
 
-In the method call example above, the recipient is shown as a human-readable 
-principal literal. In the resulting block, the same principal is encoded canonically 
-as `variant { Blob = ... }`, where the `Blob` contains the raw byte representation 
-of the principal as defined by ICRC-3. Both forms represent the same identity; 
-the difference is only in presentation.  
+In the method call example above, the recipient is specified as a Candid `Account`
+record. In the resulting block, the account is encoded as an ICRC-3 `Array` containing
+the principal's raw bytes as a `Blob`, as defined by ICRC-3.
 
 
 ### Example burn call and resulting block
@@ -328,14 +324,13 @@ the difference is only in presentation.
 The caller invokes
 ```
 icrc152_burn({
-  from            = [principal "abcd0123456789abcdef0123456789abcdef0123456789abcdef0123456789"];
+  from            = record { owner = principal "uf6dk-hyaaa-aaaaq-qaaaq-cai"; subaccount = null };
   amount          = 200_000;
   created_at_time = 1_753_344_740_000_000_000 : nat64;
-  reason          = ?"Burn to reduce supply";
+  reason          = opt "Burn to reduce supply";
 })
-
 ```
-Here, `from` is the account to be debited, `amount` is the number of tokens to burn, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
+Here, `from` is the Candid `Account` to be debited (with `owner` as a principal and an optional `subaccount`), `amount` is the number of tokens to burn, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
 
 #### Resulting block
 
@@ -351,7 +346,7 @@ variant {
         Blob = blob "\7f\89\42\a5\be\4d\af\50\3b\6e\2a\8e\9c\c7\dd\f1\c9\e8\24\f0\98\bb\d7\af\ae\d2\90\10\67\df\1e\c1\0a"
       };
     };
-    record { "ts"; variant { Nat64 = 1_753_344_740_500_000_000 : nat64 } };
+    record { "ts"; variant { Nat = 1_753_344_740_500_000_000 } };
     record {
       "tx";
       variant {
@@ -361,12 +356,12 @@ variant {
             "from";
             variant {
               Array = vec {
-                variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" }
+                variant { Blob = blob "\b4\a7\c6\39\5e\e3\69\fa\02" }
               }
             };
           };
-          record { "amt";    variant { Nat64 = 200_000 : nat64 } };
-          record { "ts";     variant { Nat64 = 1_753_344_740_000_000_000 : nat64 } };
+          record { "amt";    variant { Nat = 200_000 } };
+          record { "ts";     variant { Nat = 1_753_344_740_000_000_000 } };
           record { "caller"; variant { Blob  = blob "\00\00\00\00\02\30\02\17\01\01" } };
           record { "reason"; variant { Text  = "Burn to reduce supply" } };
         }
@@ -382,7 +377,7 @@ Here, the block records the method (`mthd = "152burn"`), the account being debit
 the burned amount (`amt`), the caller-provided timestamp (`ts`), the caller’s principal (`caller`), 
 and the optional `reason`.  
 
-In the method call example, the account is shown as a principal literal. In the resulting block, 
-the same principal is encoded canonically as `variant { Blob = ... }`. These two forms 
-represent the same identity; the difference is only in presentation.  
+In the method call example, the account is specified as a Candid `Account` record.
+In the resulting block, the account is encoded as an ICRC-3 `Array` containing the
+principal's raw bytes as a `Blob`, as defined by ICRC-3.
 

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -4,53 +4,30 @@
 |:------:|
 | Draft  |
 
-## Introduction & Motivation
+## Introduction
 
 Most ICRC-based ledgers (e.g., ICRC-1, ICRC-2) treat minting and burning as
-system-only operations that occur indirectly.
+system-only operations that occur indirectly: minting is a transfer *from* the
+minting account; burning is a transfer *into* it.
 
-- Minting is represented as a transfer from the minting account.
-- Burning is represented as a transfer into the minting account.
+This approach is insufficient for administrator-controlled or regulated assets
+such as stablecoins, Real-World Asset (RWA) tokens, or managed ledgers (NFTs,
+reward points, internal credits), where compliance requires explicit, auditable
+supply management actions by an authorized principal.
 
-This approach works for decentralized tokens but is insufficient for
-administrator-controlled or regulated assets, such as:
+ICRC-152 standardizes this by defining:
 
-- Stablecoins, which must allow an issuer to adjust circulating supply.
-- Real-World Asset (RWA) tokens, where compliance requires explicit
-  mint and burn actions.
-- Other managed ledgers (NFTs, reward points, internal credits).
+- **`icrc152_mint` and `icrc152_burn`** — privileged methods callable only by
+  authorized principals.
+- **Canonical `tx` mapping** — deterministic block content rules, including
+  optional metadata and caller tracking.
+- **ICRC-122 block kinds** — `btype = "122mint"` and `btype = "122burn"` to
+  record privileged supply actions.
+- **Compliance reporting** — via ICRC-10 methods.
 
-Without a standardized API, integrators and tooling cannot reliably
-distinguish user-initiated supply changes from privileged supply
-management actions.
-
-ICRC-152 addresses this gap by introducing:
-
-- Two privileged methods, `icrc152_mint` and `icrc152_burn`, callable only by authorized principals.
-- A canonical mapping from method inputs to block `tx` fields, including optional metadata and caller tracking.
-- Recording of these operations using the typed block kinds **defined in ICRC-122**:
-  `btype = "122mint"` for mints and `btype = "122burn"` for burns.
-
-
-## Overview
-
-ICRC-152 standardizes privileged supply management in ICRC-based ledgers.
-
-Specifically, it defines:
-
-- **APIs** for minting and burning tokens under ledger authorization.
-- **Canonical `tx` mapping** rules ensuring deterministic block content.
-- **Use of ICRC-122 block kinds** to record privileged supply actions
-  (`btype = "122mint"` and `btype = "122burn"`).
-- **Compliance reporting** through ICRC-10 methods.
-  
-
-
-This allows wallets, explorers, and auditors to:
-
-- Reliably distinguish privileged supply changes from user-initiated transfers.
-- Verify compliance with external requirements (e.g., MiCA).
-- Interoperate across ledgers that adopt the same API and block semantics.
+This allows wallets, explorers, and auditors to reliably distinguish privileged
+supply changes from user-initiated transfers, verify compliance with external
+requirements (e.g., MiCA), and interoperate across ledgers that adopt this standard.
 
 
 ## Dependencies
@@ -91,6 +68,12 @@ This standard inherits core conventions from **ICRC-3** (block log format, Value
   Resulting blocks for these APIs use `btype = "122mint"` and `btype = "122burn"` (per ICRC-122).  
   Standard metadata (e.g., `phash`, `ts`) follows ICRC-3.
 
+- **`reason` field**  
+  An optional human-readable explanation for the operation, encoded as `Text` in the block.  
+  Unlike `memo` in ICRC-1/2, which carries machine-readable bytes (e.g., an invoice number),  
+  `reason` is plain text intended for display in explorers and audit logs, with no structural  
+  constraint on its value.
+
 
 
 ## Methods
@@ -113,10 +96,13 @@ type MintArgs = record {
 };
 
 type MintError = variant {
-    Unauthorized : text;              // caller not permitted
-    InvalidAccount : text;             // target account invalid
-    Duplicate : record { duplicate_of : nat }; 
-    GenericError : record { error_code : nat; message : text };
+    Unauthorized        : text;        // caller not permitted; text is for diagnostics only
+    InvalidAccount      : text;        // target account invalid; text is for diagnostics only
+    InvalidAmount       : text;        // amount must be greater than zero
+    TooOld;
+    CreatedInFuture     : record { ledger_time : nat64 };
+    Duplicate           : record { duplicate_of : nat };
+    GenericError        : record { error_code : nat; message : text };
 };
 
 icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
@@ -146,7 +132,10 @@ icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
 **Error cases (normative)**  
 - `Unauthorized` — caller not permitted.  
 - `InvalidAccount` — malformed/invalid target account (e.g., minting account, anonymous principal, invalid subaccount bytes).  
-- `Duplicate { duplicate_of }` — a semantically identical transaction was already accepted.  
+- `InvalidAmount` — `amount` is zero.  
+- `TooOld` — `created_at_time` is before the ledger's deduplication window.  
+- `CreatedInFuture { ledger_time }` — `created_at_time` is ahead of the ledger's current time.  
+- `Duplicate { duplicate_of }` — an identical transaction was already accepted.  
 - `GenericError { error_code, message }` — any other failure preventing a valid `122mint` block.
 
 **Clarifications**  
@@ -176,6 +165,7 @@ This method allows a ledger controller (or other authorized principal) to burn
 tokens. It debits the specified account, decreases total supply, and records
 the action on-chain.
 
+#### Arguments
 ```
 type BurnArgs = record {
   from            : Account;
@@ -185,11 +175,14 @@ type BurnArgs = record {
 };
 
 type BurnError = variant {
-  Unauthorized : text;              // caller not permitted
-  InvalidAccount : text;             // source account invalid
+  Unauthorized        : text;        // caller not permitted; text is for diagnostics only
+  InvalidAccount      : text;        // source account invalid; text is for diagnostics only
+  InvalidAmount       : text;        // amount must be greater than zero
   InsufficientBalance : record { balance : nat };
-  Duplicate : record { duplicate_of : nat }; 
-  GenericError : record { error_code : nat; message : text };
+  TooOld;
+  CreatedInFuture     : record { ledger_time : nat64 };
+  Duplicate           : record { duplicate_of : nat };
+  GenericError        : record { error_code : nat; message : text };
 };
 
 icrc152_burn : (BurnArgs) -> (variant { Ok : nat; Err : BurnError });
@@ -197,45 +190,59 @@ icrc152_burn : (BurnArgs) -> (variant { Ok : nat; Err : BurnError });
 
 
 #### Semantics
-- **Debits** `amount` tokens from the `from` account.  
-- **Decreases** the total supply by `amount`.  
-- **Creates** a block of type `122burn`.  
-- On success, returns the **index of the created block**.  
-- On failure, returns an appropriate error.  
-- Semantics are consistent with the core transition already defined for `122burn` blocks.  
 
-#### Return Values
-On success, the method returns
+**Authorization**  
+- The method **MUST** be callable only by a **controller** of the ledger or other explicitly authorized principals.  
+- Unauthorized calls **MUST** fail with `Unauthorized`.
 
-- `variant { Ok : nat }`  
-  where the `nat` is the index of the block created in the ledger.  
+**Effect (on success, non-retroactive)**  
+- **Debit** `amount` from `from`.  
+- **Decrease** total supply by `amount`.  
+- **Append** a block with `btype = "122burn"`.  
+- The block's top-level `tx` **MUST** be constructed **exactly** as in **Canonical `tx` Mapping** (keys, types, encodings), and embedded in the block.
 
-On failure, the method returns
+**Return value**  
+- On success, **MUST** return `variant { Ok : nat }` where the `nat` is the index of the created block.  
+- On failure, **MUST** return `variant { Err : BurnError }`.
 
-- `variant { Err : BurnError }`  
-  describing the reason for rejection.  
+**Deduplication & idempotency**  
+- The ledger **MUST** perform deduplication (e.g., using `created_at_time` and any implementation-defined inputs).  
+- If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
+
+**Error cases (normative)**  
+- `Unauthorized` — caller not permitted.  
+- `InvalidAccount` — malformed/invalid source account (e.g., anonymous principal, invalid subaccount bytes).  
+- `InvalidAmount` — `amount` is zero.  
+- `InsufficientBalance { balance }` — the `from` account holds fewer tokens than `amount`.  
+- `TooOld` — `created_at_time` is before the ledger's deduplication window.  
+- `CreatedInFuture { ledger_time }` — `created_at_time` is ahead of the ledger's current time.  
+- `Duplicate { duplicate_of }` — an identical transaction was already accepted.  
+- `GenericError { error_code, message }` — any other failure preventing a valid `122burn` block.
+
+**Clarifications**  
+- Optional fields **MUST be omitted** from `tx` if not supplied in the call (no null placeholders).  
+- Representation-independent hashing (ICRC-3) applies; field presence and values matter, not map ordering.
 
 
-#### Canonical `tx` Mapping
-A successful call to `icrc152_burn` produces a block of type `122burn`.  
+#### Canonical `tx` Mapping (normative)
+A successful call to `icrc152_burn` produces a block of type `122burn`.
 The `tx` field is derived deterministically as follows:
 
-- `mthd   = "152burn"`  
-- `from   = BurnArgs.from`  
-- `amt    = BurnArgs.amount`  
-- `ts     = BurnArgs.created_at_time`  
-- `caller = caller_principal (as Blob)`  
-- `reason = BurnArgs.reason` (if provided)  
-
-Optional fields (`reason`) MUST be omitted from `tx` if not supplied in the call.  
+| Field             | Type (ICRC-3 `Value`) | Source / Encoding Rule                                                      |
+|-------------------|------------------------|-----------------------------------------------------------------------------|
+| `mthd`            | `Text`                 | **Constant** `"152burn"`.                                                   |
+| `from`            | `Array` (Account)      | From `BurnArgs.from`, encoded as ICRC-3 Account.                            |
+| `amt`             | `Nat`                  | From `BurnArgs.amount`.                                                     |
+| `ts`              | `Nat`                  | From `BurnArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
+| `caller`          | `Blob`                 | Principal of the caller (raw bytes).                                        |
+| `reason`          | `Text` *(optional)*    | From `BurnArgs.reason` if provided; **omit** if absent.                     |
 
 ### Reporting Compliance
 
 #### Supported Standards
 
 Ledgers implementing ICRC-152 MUST indicate compliance through the
-`icrc1_supported_standards` and `icrc10_supported_standards` methods, by
-including in the output of these methods:
+`icrc10_supported_standards` method by including in its output:
 
 ```
 vec {
@@ -245,6 +252,9 @@ vec {
     }
 }
 ```
+
+Ledgers that also implement ICRC-1 MUST additionally include this entry in
+the output of `icrc1_supported_standards`.
 
 #### Supported Block Types
 
@@ -291,7 +301,7 @@ variant {
             "to";
             variant {
               Array = vec {
-                variant { Blob = blob "\d3\e2\95\d8\63\bc\ef\0d\02" }
+                variant { Blob = blob "\00\00\00\00\00\00\00\02\01\01" }
               }
             };
           };
@@ -309,8 +319,8 @@ variant {
 
 
 
-The block records the method (`mthd = "152mint"`), the recipient account (`to`), 
-the minted amount (`amt`), the timestamp supplied by the caller (`ts`), the caller’s 
+The block records the method (`mthd = "152mint"`), the recipient account (`to`),
+the minted amount (`amt`), the timestamp supplied by the caller (`ts`), the caller’s
 principal (`caller`), and the optional `reason`.  
 
 In the method call example above, the recipient is specified as a Candid `Account`
@@ -343,7 +353,7 @@ variant {
     record {
       "phash";
       variant {
-        Blob = blob "\7f\89\42\a5\be\4d\af\50\3b\6e\2a\8e\9c\c7\dd\f1\c9\e8\24\f0\98\bb\d7\af\ae\d2\90\10\67\df\1e\c1\0a"
+        Blob = blob "\7f\89\42\a5\be\4d\af\50\3b\6e\2a\8e\9c\c7\dd\f1\c9\e8\24\f0\98\bb\d7\af\ae\d2\90\10\67\df\1e\c1"
       };
     };
     record { "ts"; variant { Nat = 1_753_344_740_500_000_000 } };
@@ -356,7 +366,7 @@ variant {
             "from";
             variant {
               Array = vec {
-                variant { Blob = blob "\b4\a7\c6\39\5e\e3\69\fa\02" }
+                variant { Blob = blob "\00\00\00\00\02\10\00\01\01\01" }
               }
             };
           };
@@ -373,11 +383,16 @@ variant {
 
 ```
 
-Here, the block records the method (`mthd = "152burn"`), the account being debited (`from`), 
-the burned amount (`amt`), the caller-provided timestamp (`ts`), the caller’s principal (`caller`), 
-and the optional `reason`.  
+Here, the block records the method (`mthd = "152burn"`), the account being debited (`from`),
+the burned amount (`amt`), the caller-provided timestamp (`ts`), the caller’s principal (`caller`),
+and the optional `reason`.
+
+The block contains two `ts` fields. The top-level `ts` (`1_753_344_740_500_000_000`) is the
+ledger’s consensus timestamp, assigned when the block is committed to the log. The `tx.ts`
+(`1_753_344_740_000_000_000`) is the caller-supplied `created_at_time` copied from `BurnArgs`.
+These will generally differ.
 
 In the method call example, the account is specified as a Candid `Account` record.
 In the resulting block, the account is encoded as an ICRC-3 `Array` containing the
-principal's raw bytes as a `Blob`, as defined by ICRC-3.
+principal’s raw bytes as a `Blob`, as defined by ICRC-3.
 

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -126,7 +126,8 @@ icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
 - On failure, **MUST** return `variant { Err : MintError }`.
 
 **Deduplication & idempotency**  
-- The ledger **MUST** perform deduplication (e.g., using `created_at_time` and any implementation-defined inputs).  
+- `created_at_time` is required (not optional) because deduplication is always mandatory for privileged operations — accidental duplicate supply changes must be prevented regardless of caller intent.  
+- The ledger **MUST** perform deduplication using `created_at_time` and any implementation-defined inputs.  
 - If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
 **Error cases (normative)**  
@@ -206,7 +207,8 @@ icrc152_burn : (BurnArgs) -> (variant { Ok : nat; Err : BurnError });
 - On failure, **MUST** return `variant { Err : BurnError }`.
 
 **Deduplication & idempotency**  
-- The ledger **MUST** perform deduplication (e.g., using `created_at_time` and any implementation-defined inputs).  
+- `created_at_time` is required (not optional) because deduplication is always mandatory for privileged operations — accidental duplicate supply changes must be prevented regardless of caller intent.  
+- The ledger **MUST** perform deduplication using `created_at_time` and any implementation-defined inputs.  
 - If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
 **Error cases (normative)**  

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -1,0 +1,220 @@
+# `ICRC‑152`: Privileged Mint & Burn API
+
+| Status |
+|:------:|
+| Draft  |
+
+`ICRC‑152` defines privileged minting and burning operations for ICRC‑compliant ledgers. It specifies two methods—`icrc152_mint` and `icrc152_burn`—and describes the canonical block representation of each call according to `ICRC‑3`. The methods map to `122mint` and `122burn` block types, while the `tx.op` field is namespaced with `152`. Each `tx` also records the caller’s principal and an optional human‑readable reason.
+
+
+
+## Type Definitions
+
+
+```
+type MintArgs = record {
+  to              : Account;    // target account receiving the minted tokens
+  amount          : nat;        // number of tokens to mint
+  created_at_time : nat64;      // timestamp in nanoseconds since Unix epoch
+  reason          : opt text;   // optional human-readable reason for the mint
+};
+
+type BurnArgs = record {
+  from            : Account;    // account from which tokens are burned
+  amount          : nat;        // number of tokens to burn
+  created_at_time : nat64;      // timestamp in nanoseconds since Unix epoch
+  reason          : opt text;   // optional human-readable reason for the burn
+};
+
+type MintError = variant {
+  Unauthorized;
+  InvalidAccount;
+  CreatedInFuture;
+  Duplicate;
+  TemporarilyUnavailable;
+  Other : text;
+};
+
+type BurnError = variant {
+  Unauthorized;
+  InsufficientBalance;
+  InvalidAccount;
+  CreatedInFuture;
+  Duplicate;
+  TemporarilyUnavailable;
+  Other : text;
+};
+```
+
+
+## Method Signatures
+
+```
+icrc152_mint : (MintArgs) -> (variant { Ok : nat; Err : MintError });
+
+icrc152_burn : (BurnArgs) -> (variant { Ok : nat; Err : BurnError });
+```
+
+## Semantics
+
+- **Authorisation:** The ledger MUST verify that the caller is authorised to mint or burn. If not, it returns `Err.Unauthorized`.
+- **Supply update:**  
+  - For `icrc152_mint`, increase the total supply by `amount` and credit `amount` to the `to` account.  
+  - For `icrc152_burn`, decrease the total supply by `amount` and debit `amount` from the `from` account. If the `from` account does not hold enough tokens, the ledger MUST return `Err.InsufficientBalance`.
+- **Fees:** Neither operation charges a fee under this specification.
+- **Return value:** On success, return the index of the newly appended block as `Ok(nat)`.
+- **Caller field:** The `caller` field in the `tx` record MUST contain the principal of the caller encoded as a blob. This field is informational and does not affect the state transition.
+
+
+## Canonical `tx` Mapping for Successful Calls
+
+### Mint block (btype = "122mint")
+
+```
+tx.op     = "152mint"
+tx.to     = MintArgs.to
+tx.amt    = MintArgs.amount
+tx.ts     = MintArgs.created_at_time
+tx.caller = caller_principal (as Blob)
+tx.reason = MintArgs.reason (if provided)
+```
+
+### Burn block (btype = "122burn")
+```
+tx.op     = "152burn"
+tx.from   = BurnArgs.from
+tx.amt    = BurnArgs.amount
+tx.ts     = BurnArgs.created_at_time
+tx.caller = caller_principal (as Blob)
+tx.reason = BurnArgs.reason (if provided)
+```
+
+
+### Example mint call and resulting block
+
+#### Call
+The caller invokes
+```
+icrc152_mint({
+  to              = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
+  amount          = 500_000;
+  created_at_time = 1_753_344_737_123_456_789 : nat64;
+  reason          = ?"Initial allocation";
+})
+```
+Here, `to` is the account of the recipient, `amount` is the number of tokens to mint, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
+
+#### Resulting block
+
+This call results in a block with btype = "122mint" and the following contents:
+
+```
+variant {
+  Map = vec {
+    record { "btype"; variant { Text = "122mint" } };
+    record {
+      "phash";
+      variant {
+        Blob = blob "\a0\5f\d2\f3\4c\26\73\58\00\7f\ea\02\18\43\47\70\85\50\2e\d2\1f\23\e0\dc\e6\af\3c\cf\9e\6f\4a\d8"
+      };
+    };
+    record { "ts"; variant { Nat64 = 1_753_344_738_000_000_000 : nat64 } };
+    record {
+      "tx";
+      variant {
+        Map = vec {
+          record { "op";     variant { Text  = "152mint" } };
+          record {
+            "to";
+            variant {
+              Array = vec {
+                variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
+              }
+            };
+          };
+          record { "amt";    variant { Nat64 = 500_000 : nat64 } };
+          record { "ts";     variant { Nat64 = 1_753_344_737_123_456_789 : nat64 } };
+          record { "caller"; variant { Blob  = blob "\00\00\00\00\02\30\02\17\01\01" } };
+          record { "reason"; variant { Text  = "Initial allocation" } };
+        }
+      };
+    };
+  }
+};
+
+```
+
+The block records the operation (`op = "152mint"`), the recipient account (`to`), the minted amount (`amt`), the timestamp supplied by the caller (`ts`), the caller’s principal (`caller`) and the optional `reason`.
+
+### Example burn call and resulting block
+
+#### Call
+The caller invokes
+```
+icrc152_burn({
+  from            = [principal "abcd0123456789abcdef0123456789abcdef0123456789abcdef0123456789"];
+  amount          = 200_000;
+  created_at_time = 1_753_344_740_000_000_000 : nat64;
+  reason          = ?"Burn to reduce supply";
+})
+
+```
+Here, `from` s the account to be debited,, `amount` is the number of tokens to burn, `created_at_time` is the caller‑supplied timestamp, and `reason` provides an optional human‑readable note.
+
+#### Resulting block
+
+This call results in a block with btype = "122burn" and the following contents:
+
+```
+variant {
+  Map = vec {
+    record { "btype"; variant { Text = "122burn" } };
+    record {
+      "phash";
+      variant {
+        Blob = blob "\7f\89\42\a5\be\4d\af\50\3b\6e\2a\8e\9c\c7\dd\f1\c9\e8\24\f0\98\bb\d7\af\ae\d2\90\10\67\df\1e\c1\0a"
+      };
+    };
+    record { "ts"; variant { Nat64 = 1_753_344_740_500_000_000 : nat64 } };
+    record {
+      "tx";
+      variant {
+        Map = vec {
+          record { "op";     variant { Text  = "152burn" } };
+          record {
+            "from";
+            variant {
+              Array = vec {
+                variant { Blob = blob  
+                "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" }
+              }
+            };
+          };
+          record { "amt";    variant { Nat64 = 200_000 : nat64 } };
+          record { "ts";     variant { Nat64 = 1_753_344_740_000_000_000 : nat64 } };
+          record { "caller"; variant { Blob  = blob "\00\00\00\00\02\30\02\17\01\01" } };
+          record { "reason"; variant { Text  = "Burn to reduce supply" } };
+        }
+      };
+    };
+  }
+};
+
+
+```
+
+Here, the block records the operation (`op = "152burn"`), the account being debited (`from`), the burned amount (`amt`), the caller‑provided timestamp (`ts`), the caller’s principal (`caller`) and the optional `reason`. 
+
+
+
+
+## Supported block types (for `icrc3_supported_block_types`)
+```
+vec {
+  record { block_type = "122mint"; url = "https://example.com/ICRC-122.md#122mint" },
+  record { block_type = "122burn"; url = "https://example.com/ICRC-122.md#122burn" },
+}
+
+
+```
+

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -66,7 +66,7 @@ This standard does not introduce new block kinds.
 A ledger implementing ICRC-152 MUST:
 - Emit `122mint` for successful `icrc152_mint` calls and `122burn` for successful
   `icrc152_burn` calls.
-- Populate `tx.op` with namespaced values **introduced by this standard**:
+- Populate `tx.mthd` with namespaced values **introduced by this standard**:
   `"152mint"` and `"152burn"`.
 
 
@@ -162,7 +162,7 @@ The `tx` field is derived deterministically as follows:
 
 | Field             | Type (ICRC-3 `Value`) | Source / Encoding Rule                                                     |
 |-------------------|------------------------|-----------------------------------------------------------------------------|
-| `op`              | `Text`                 | **Constant** `"152mint"`.                                                  |
+| `mthd`            | `Text`                 | **Constant** `"152mint"`.                                                  |
 | `to`              | `Array` (Account)      | From `MintArgs.to`, encoded as ICRC-3 Account.                             |
 | `amt`             | `Nat`                  | From `MintArgs.amount`.                                                    |
 | `created_at_time` | `Nat`                  | From `MintArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
@@ -222,7 +222,7 @@ On failure, the method returns
 A successful call to `icrc152_burn` produces a block of type `122burn`.  
 The `tx` field is derived deterministically as follows:
 
-- `op     = "152burn"`  
+- `mthd   = "152burn"`  
 - `from   = BurnArgs.from`  
 - `amt    = BurnArgs.amount`  
 - `ts     = BurnArgs.created_at_time`  
@@ -288,7 +288,7 @@ variant {
       "tx";
       variant {
         Map = vec {
-          record { "op";     variant { Text  = "152mint" } };
+          record { "mthd";   variant { Text  = "152mint" } };
           record {
             "to";
             variant {
@@ -311,7 +311,7 @@ variant {
 
 
 
-The block records the operation (`op = "152mint"`), the recipient account (`to`), 
+The block records the method (`mthd = "152mint"`), the recipient account (`to`), 
 the minted amount (`amt`), the timestamp supplied by the caller (`ts`), the caller’s 
 principal (`caller`), and the optional `reason`.  
 
@@ -356,7 +356,7 @@ variant {
       "tx";
       variant {
         Map = vec {
-          record { "op";     variant { Text  = "152burn" } };
+          record { "mthd";   variant { Text  = "152burn" } };
           record {
             "from";
             variant {
@@ -378,7 +378,7 @@ variant {
 
 ```
 
-Here, the block records the operation (`op = "152burn"`), the account being debited (`from`), 
+Here, the block records the method (`mthd = "152burn"`), the account being debited (`from`), 
 the burned amount (`amt`), the caller-provided timestamp (`ts`), the caller’s principal (`caller`), 
 and the optional `reason`.  
 

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -165,7 +165,7 @@ The `tx` field is derived deterministically as follows:
 | `mthd`            | `Text`                 | **Constant** `"152mint"`.                                                  |
 | `to`              | `Array` (Account)      | From `MintArgs.to`, encoded as ICRC-3 Account.                             |
 | `amt`             | `Nat`                  | From `MintArgs.amount`.                                                    |
-| `created_at_time` | `Nat`                  | From `MintArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
+| `ts`              | `Nat`                  | From `MintArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
 | `caller`          | `Blob`                 | Principal of the caller (raw bytes).                                       |
 | `reason`          | `Text` *(optional)*    | From `MintArgs.reason` if provided; **omit** if absent.                    |
 

--- a/ICRCs/ICRC-152/ICRC-152.md
+++ b/ICRCs/ICRC-152/ICRC-152.md
@@ -206,15 +206,3 @@ variant {
 Here, the block records the operation (`op = "152burn"`), the account being debited (`from`), the burned amount (`amt`), the caller‑provided timestamp (`ts`), the caller’s principal (`caller`) and the optional `reason`. 
 
 
-
-
-## Supported block types (for `icrc3_supported_block_types`)
-```
-vec {
-  record { block_type = "122mint"; url = "https://example.com/ICRC-122.md#122mint" },
-  record { block_type = "122burn"; url = "https://example.com/ICRC-122.md#122burn" },
-}
-
-
-```
-


### PR DESCRIPTION
This PR introduces ICRC-152, a standard API for privileged mint and burn operations in ICRC-ledgers. It defines icrc152_mint and icrc152_burn methods, the canonical tx mapping, and recording of operations using block kinds defined in ICRC-122. The goal is to provide a reliable, auditable interface for supply management in stablecoins, RWAs, and other administrator-controlled tokens.