### PR TITLE
ICRC-153: Standardizing Privileged Freeze & Unfreeze Controls

### DIFF
--- a/ICRCs/ICRC-153/ICRC-153.did
+++ b/ICRCs/ICRC-153/ICRC-153.did
@@ -65,11 +65,33 @@ type UnfreezePrincipalError = variant {
   GenericError     : record { error_code : nat; message : text };
 };
 
+type FrozenAccountsRequest = record {
+  start_after : opt Account;
+  max_results : nat;
+};
+
+type FrozenAccountsResponse = record {
+  accounts : vec Account;
+  has_more : bool;
+};
+
+type FrozenPrincipalsRequest = record {
+  start_after : opt principal;
+  max_results : nat;
+};
+
+type FrozenPrincipalsResponse = record {
+  principals : vec principal;
+  has_more  : bool;
+};
+
 service : {
-  icrc153_freeze_account    : (FreezeAccountArgs)    -> (variant { Ok : nat; Err : FreezeAccountError });
-  icrc153_unfreeze_account  : (UnfreezeAccountArgs)  -> (variant { Ok : nat; Err : UnfreezeAccountError });
-  icrc153_freeze_principal  : (FreezePrincipalArgs)  -> (variant { Ok : nat; Err : FreezePrincipalError });
+  icrc153_freeze_account     : (FreezeAccountArgs)     -> (variant { Ok : nat; Err : FreezeAccountError });
+  icrc153_unfreeze_account   : (UnfreezeAccountArgs)   -> (variant { Ok : nat; Err : UnfreezeAccountError });
+  icrc153_freeze_principal   : (FreezePrincipalArgs)   -> (variant { Ok : nat; Err : FreezePrincipalError });
   icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err : UnfreezePrincipalError });
-  icrc153_is_frozen_account   : (Account)    -> (bool) query;
-  icrc153_is_frozen_principal : (principal)  -> (bool) query;
+  icrc153_is_frozen_account     : (Account)   -> (bool) query;
+  icrc153_is_frozen_principal   : (principal) -> (bool) query;
+  icrc153_list_frozen_accounts   : (FrozenAccountsRequest)   -> (FrozenAccountsResponse)   query;
+  icrc153_list_frozen_principals : (FrozenPrincipalsRequest) -> (FrozenPrincipalsResponse) query;
 };

--- a/ICRCs/ICRC-153/ICRC-153.did
+++ b/ICRCs/ICRC-153/ICRC-153.did
@@ -1,0 +1,75 @@
+type Account = record {
+  owner      : principal;
+  subaccount : opt blob;
+};
+
+type FreezeAccountArgs = record {
+  account         : Account;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type FreezeAccountError = variant {
+  Unauthorized     : text;
+  InvalidAccount   : text;
+  AlreadyFrozen    : text;
+  TooOld;
+  CreatedInFuture  : record { ledger_time : nat64 };
+  Duplicate        : record { duplicate_of : nat };
+  GenericError     : record { error_code : nat; message : text };
+};
+
+type UnfreezeAccountArgs = record {
+  account         : Account;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type UnfreezeAccountError = variant {
+  Unauthorized    : text;
+  InvalidAccount  : text;
+  TooOld;
+  CreatedInFuture : record { ledger_time : nat64 };
+  Duplicate       : record { duplicate_of : nat };
+  GenericError    : record { error_code : nat; message : text };
+};
+
+type FreezePrincipalArgs = record {
+  principal       : principal;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type FreezePrincipalError = variant {
+  Unauthorized     : text;
+  InvalidPrincipal : text;
+  AlreadyFrozen    : text;
+  TooOld;
+  CreatedInFuture  : record { ledger_time : nat64 };
+  Duplicate        : record { duplicate_of : nat };
+  GenericError     : record { error_code : nat; message : text };
+};
+
+type UnfreezePrincipalArgs = record {
+  principal       : principal;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type UnfreezePrincipalError = variant {
+  Unauthorized     : text;
+  InvalidPrincipal : text;
+  TooOld;
+  CreatedInFuture  : record { ledger_time : nat64 };
+  Duplicate        : record { duplicate_of : nat };
+  GenericError     : record { error_code : nat; message : text };
+};
+
+service : {
+  icrc153_freeze_account    : (FreezeAccountArgs)    -> (variant { Ok : nat; Err : FreezeAccountError });
+  icrc153_unfreeze_account  : (UnfreezeAccountArgs)  -> (variant { Ok : nat; Err : UnfreezeAccountError });
+  icrc153_freeze_principal  : (FreezePrincipalArgs)  -> (variant { Ok : nat; Err : FreezePrincipalError });
+  icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err : UnfreezePrincipalError });
+  icrc153_is_frozen_account   : (Account)    -> (bool) query;
+  icrc153_is_frozen_principal : (principal)  -> (bool) query;
+};

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -479,37 +479,52 @@ Principals MUST be ordered by their raw principal **bytes** (as if `variant { Bl
 
 ## Effective Freeze Model (Clarification)
 
-ICRC-153 adopts a **compositional freeze rule** consistent with ICRC-123:
+ICRC-153 adopts the **latest-action-wins** rule defined in ICRC-123:
 
-- An **account** is *effectively frozen* if **either**:
-  1) the account itself is frozen, **or**
-  2) the account’s `owner` **principal** is frozen.
+- An **account** `acc = (owner, subaccount)` is *effectively frozen* iff the most
+  recent freeze/unfreeze block that **affects** `acc` is a freeze block.
+- A block **affects** `acc` if:
+  1) it is a `123freezeaccount` or `123unfreezeaccount` block where `tx.account` matches `acc`, **or**
+  2) it is a `123freezeprincipal` or `123unfreezeprincipal` block where `tx.principal` equals `owner`.
+- If no block affects `acc`, the account is **not frozen**.
+
+### Key implications
+
+- Unfreezing a **principal** lifts all earlier account-level freezes for that
+  principal’s accounts (since the principal unfreeze is more recent).
+- Freezing an **account** after unfreezing its principal re-freezes only that
+  specific account.
+- The effective status of any account is always determined by comparing the
+  block index of the latest account-level action (if any) with the latest
+  principal-level action (if any); whichever is more recent wins.
 
 ### Implications for Queries
 
-- `icrc153_list_frozen_accounts`  
-  Returns **only accounts frozen directly** (i.e., via account-level freezes).  
-  It does **not** expand principal-level freezes into per-account entries.
+- `icrc153_list_frozen_accounts`
+  Returns accounts whose most recent **account-level** action was a freeze.
+  It does **not** expand principal-level freezes into per-account entries, nor
+  does it exclude accounts that have been effectively unfrozen by a later
+  principal-level unfreeze.
 
-- `icrc153_list_frozen_principals`  
-  Returns **principals** that are frozen. Any account owned by a listed principal is
-  *effectively frozen* by composition, even if it does not appear in the account list.
+- `icrc153_list_frozen_principals`
+  Returns principals whose most recent **principal-level** action was a freeze.
 
-- `icrc153_is_frozen_account(account)` MUST return `true` if the account is directly frozen
-  **or** if `is_frozen_principal(account.owner)` is `true`.
+- `icrc153_is_frozen_account(account)` MUST return `true` iff the account is
+  *effectively frozen* under the latest-action-wins rule (considering both
+  account-level and principal-level actions).
 
-- `icrc153_is_frozen_principal(principal)` returns whether the **principal-level** freeze is active.
+- `icrc153_is_frozen_principal(principal)` returns whether the most recent
+  **principal-level** action was a freeze.
 
 ### Integrator Guidance
 
-To determine whether a given account is currently frozen, integrators MUST either:
-- call `icrc153_is_frozen_account(account)`, or
-- check both lists and apply the compositional rule:
-  1) see if `account` appears in `icrc153_list_frozen_accounts`, or
-  2) see if `account.owner` appears in `icrc153_list_frozen_principals`.
+To determine whether a given account is currently frozen, integrators SHOULD
+call `icrc153_is_frozen_account(account)`, which applies the full
+latest-action-wins rule.
 
-This approach avoids large state updates when freezing/unfreezing principals with many accounts,
-while providing a clear, deterministic interpretation of the effective freeze state.
+Alternatively, integrators can reconstruct the effective status from the
+listing endpoints, but they MUST compare the block indices of the most recent
+account-level and principal-level actions rather than applying a simple OR.
 
 
 ## Example: Freeze and Unfreeze — method calls and resulting blocks

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -438,3 +438,59 @@ To determine whether a given account is currently frozen, integrators MUST eithe
 
 This approach avoids large state updates when freezing/unfreezing principals with many accounts,
 while providing a clear, deterministic interpretation of the effective freeze state.
+
+
+## Example calls and the resulting blocks
+
+#### Call
+The caller invokes:
+
+```
+icrc153_freeze_account({
+  account         = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
+  created_at_time = 1_753_500_100_000_000_000 : nat64;
+  reason          = ?"Fraud investigation hold";
+})
+```
+
+#### Resulting block
+
+This call rsults in a block with btype="122freeze" and the following contents:
+
+```
+variant {
+  Map = vec {
+    record { "btype"; variant { Text = "123freeze_account" } };
+    record { "phash"; variant { Blob = blob "\12\34\56\78\9a\bc\de\f0\01\23\45\67\89\ab\cd\ef\10\32\54\76\98\ba\dc\fe\11\22\33\44\55\66\77\88" } };
+    record { "ts";    variant { Nat64 = 1_753_500_101_000_000_000 : nat64 } };
+    record {
+      "tx";
+      variant {
+        Map = vec {
+          record { "op";      variant { Text = "153freeze_account" } };
+          record { "account"; variant { Array = vec {
+            variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
+          } } };
+          record { "ts";      variant { Nat64 = 1_753_500_100_000_000_000 : nat64 } };
+          record { "caller";  variant { Blob  = blob "\00\00\00\00\02\30\02\17\01\01" } };
+          record { "reason";  variant { Text  = "Fraud investigation hold" } };
+        }
+      };
+    };
+  }
+};
+```
+
+The block records the operation (op = "153freeze_account"), the account being frozen (account), the caller-supplied timestamp (ts), the caller’s principal (caller), and the optional reason. The account is shown as a principal literal in the call, but stored canonically as a Blob in the block.
+
+#### Call
+The caller invokes:
+```
+icrc153_unfreeze_account({
+  account         = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
+  created_at_time = 1_753_500_100_000_000_000 : nat64;
+  reason          = ?"Lift compliance hold";
+})
+```
+
+

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -4,38 +4,18 @@
 |:------:|
 | Draft  |
 
-## Introduction & Motivation
+## Introduction
 
-Operational and regulatory requirements for custodial tokens, stablecoins, and RWA ledgers often include the ability to **freeze** (temporarily disable) or **unfreeze** transfer activity for specific **accounts** or for all accounts belonging to a **principal**. Absent a standard interface, integrators cannot reliably determine whether funds are movable, nor attribute freezes to clear, on-chain actions.
+Operational and regulatory requirements for custodial tokens, stablecoins, and RWA ledgers often require the ability to freeze or unfreeze transfer activity for specific accounts or principals. Absent a standard interface, integrators cannot reliably determine whether funds are movable, nor attribute freezes to clear, on-chain actions.
 
-ICRC-153 addresses this by standardizing four privileged methods that append canonical, typed blocks (as defined in **ICRC-123**) and by defining the canonical mapping from method inputs to the `tx` field for those blocks.
+ICRC-153 standardizes this by defining four privileged methods that append canonical, typed blocks to the ledger (as defined in **ICRC-123**):
 
-**Privileged methods (authorized principals only):**
-- `icrc153_freeze_account`, `icrc153_unfreeze_account`
-- `icrc153_freeze_principal`, `icrc153_unfreeze_principal`
+- **`icrc153_freeze_account`** / **`icrc153_unfreeze_account`** — freeze or unfreeze a specific account.
+- **`icrc153_freeze_principal`** / **`icrc153_unfreeze_principal`** — freeze or unfreeze all accounts belonging to a principal.
 
-**Canonical `tx` mapping** with namespaced `mthd` values (`"153..."`), caller identity, and optional human-readable reason.
+Two query methods (`icrc153_list_frozen_accounts`, `icrc153_list_frozen_principals`) and two status checks (`icrc153_is_frozen_account`, `icrc153_is_frozen_principal`) allow wallets, explorers, and auditors to determine freeze state on-chain and attribute actions to specific authorized callers.
 
-Recording uses **ICRC-123** block kinds (this standard does **not** add new block types).
-
-## Overview
-
-ICRC-153 standardizes privileged freeze/unfreeze controls for ICRC ledgers.
-
-Specifically, it defines:
-
-- **APIs** to freeze/unfreeze **accounts** and **principals**, callable only by authorized entities.
-- **Canonical `tx` mapping** rules ensuring deterministic block content and easy attribution/auditing.
-- **Use of ICRC-123 block kinds** to record these actions:
-  - `btype = "123freezeaccount"`, `btype = "123unfreezeaccount"`
-  - `btype = "123freezeprincipal"`, `btype = "123unfreezeprincipal"`
-- **Compliance reporting** through ICRC-10 methods.
-
-This enables wallets, explorers, and auditors to:
-
-- Determine, on-chain, whether an account or a principal is currently frozen.
-- Attribute actions to a specific authorized caller and (optionally) a recorded reason.
-- Interoperate across ledgers that implement the same API and block semantics.
+Recording uses **ICRC-123** block kinds; this standard does not add new block types.
 
 ## Dependencies
 
@@ -68,8 +48,7 @@ This standard inherits core conventions from **ICRC-3** (block log format, Value
   Encoded as `variant { Blob = <principal_bytes> }`.
 
 - **Timestamps**  
-  Caller-supplied `created_at_time` is in **nanoseconds since Unix epoch**.  
-  Encoded as `Nat` in ICRC-3 `Value` and **MUST** fit in `nat64`.
+  The caller-supplied timestamp is recorded as `ts` in the block's `tx` map, in **nanoseconds since Unix epoch**, encoded as `Nat` in ICRC-3 `Value` and **MUST** fit in `nat64`.
 
 - **Blocks & Parent Hash**  
   All blocks created by this API use the ICRC-123 block kinds  
@@ -95,8 +74,10 @@ type FreezeAccountArgs = record {
 type FreezeAccountError = variant {
   Unauthorized : text;               // caller not permitted
   InvalidAccount : text;             // malformed or disallowed account
-  AlreadyFrozen : text;              // account is already frozen
-  Duplicate : record { duplicate_of : nat };
+  AlreadyFrozen   : text;              // account is already frozen
+  TooOld;
+  CreatedInFuture  : record { ledger_time : nat64 };
+  Duplicate        : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text };
 };
 
@@ -126,7 +107,9 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 - `Unauthorized` — caller not permitted.  
 - `InvalidAccount` — malformed or disallowed account (e.g., minting account, malformed principal/subaccount).  
 - `AlreadyFrozen` — account already frozen.  
-- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+- `TooOld` — `created_at_time` is before the ledger's deduplication window.  
+- `CreatedInFuture { ledger_time }` — `created_at_time` is ahead of the ledger's current time.  
+- `Duplicate { duplicate_of }` — identical transaction previously accepted.  
 - `GenericError { error_code, message }` — any other failure preventing a valid block.
 
 **Clarifications**  
@@ -139,7 +122,7 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 |-------------------|------------------------|-------------------------|
 | `mthd`            | `Text`                 | **Constant** `"153freeze_account"`. |
 | `account`         | `Array` (Account)      | From `FreezeAccountArgs.account`, encoded as ICRC-3 Account. |
-| `created_at_time` | `Nat`                  | From `FreezeAccountArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
+| `ts`              | `Nat`                  | From `FreezeAccountArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
 | `caller`          | `Blob`                 | Principal of the caller (raw bytes). |
 | `reason`          | `Text` *(optional)*    | From `FreezeAccountArgs.reason` if provided; **omit** if absent. |
 
@@ -161,9 +144,11 @@ type UnfreezeAccountArgs = record {
 };
 
 type UnfreezeAccountError = variant {
-  Unauthorized : text;
-  InvalidAccount : text;
-  Duplicate : record { duplicate_of : nat };
+  Unauthorized    : text;
+  InvalidAccount  : text;
+  TooOld;
+  CreatedInFuture : record { ledger_time : nat64 };
+  Duplicate       : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text };
 };
 
@@ -193,7 +178,9 @@ icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (variant { Ok : nat; Err : U
 **Error cases (normative)**
 - `Unauthorized` — caller not permitted.
 - `InvalidAccount` — malformed or disallowed account.
-- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.
+- `TooOld` — `created_at_time` is before the ledger's deduplication window.
+- `CreatedInFuture { ledger_time }` — `created_at_time` is ahead of the ledger's current time.
+- `Duplicate { duplicate_of }` — identical transaction previously accepted.
 - `GenericError { error_code, message }` — any other failure preventing a valid block.
 
 **Clarifications**
@@ -229,8 +216,10 @@ type FreezePrincipalArgs = record {
 type FreezePrincipalError = variant {
   Unauthorized : text;
   InvalidPrincipal : text;
-  AlreadyFrozen : text;              // principal is already frozen at scope defined by ICRC-123
-  Duplicate : record { duplicate_of : nat };
+  AlreadyFrozen    : text;              // principal is already frozen at scope defined by ICRC-123
+  TooOld;
+  CreatedInFuture  : record { ledger_time : nat64 };
+  Duplicate        : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text };
 };
 
@@ -261,7 +250,9 @@ icrc153_freeze_principal : (FreezePrincipalArgs) -> (variant { Ok : nat; Err : F
 - `Unauthorized` — caller not permitted.  
 - `InvalidPrincipal` — malformed/invalid principal bytes.  
 - `AlreadyFrozen` — principal already frozen at the scope defined by ICRC-123.  
-- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+- `TooOld` — `created_at_time` is before the ledger's deduplication window.  
+- `CreatedInFuture { ledger_time }` — `created_at_time` is ahead of the ledger's current time.  
+- `Duplicate { duplicate_of }` — identical transaction previously accepted.  
 - `GenericError { error_code, message }` — any other failure preventing a valid block.
 
 **Clarifications**  
@@ -296,9 +287,11 @@ type UnfreezePrincipalArgs = record {
 };
 
 type UnfreezePrincipalError = variant {
-  Unauthorized : text;
+  Unauthorized     : text;
   InvalidPrincipal : text;
-  Duplicate : record { duplicate_of : nat };
+  TooOld;
+  CreatedInFuture  : record { ledger_time : nat64 };
+  Duplicate        : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text };
 };
 
@@ -328,7 +321,9 @@ icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err
 **Error cases (normative)**
 - `Unauthorized` — caller not permitted.
 - `InvalidPrincipal` — malformed/invalid principal bytes.
-- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.
+- `TooOld` — `created_at_time` is before the ledger's deduplication window.
+- `CreatedInFuture { ledger_time }` — `created_at_time` is ahead of the ledger's current time.
+- `Duplicate { duplicate_of }` — identical transaction previously accepted.
 - `GenericError { error_code, message }` — any other failure preventing a valid block.
 
 **Clarifications**
@@ -363,13 +358,13 @@ Ledgers implementing ICRC-153 MUST indicate compliance through the
 `icrc1_supported_standards` and `icrc10_supported_standards` methods by
 including:
 
-```
-variant { Vec = vec {
-  record {
-    "name"; variant { Text = "ICRC-153" };
-    "url";  variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-153.md" };
-  }
-}};
+```candid
+vec {
+    record {
+        name = "ICRC-153";
+        url  = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-153/ICRC-153.md";
+    }
+}
 ```
 
 ### Supported Block Types
@@ -475,6 +470,28 @@ Principals MUST be ordered by their raw principal **bytes** (as if `variant { Bl
 - Implementations SHOULD bound `max_results`.
 - Results are a **point-in-time snapshot**; concurrent changes may affect subsequent pages.
 
+### `icrc153_is_frozen_account`
+
+Returns whether a given account is currently effectively frozen.
+
+```
+icrc153_is_frozen_account : (Account) -> (bool) query;
+```
+
+Returns `true` iff the account is *effectively frozen* under ICRC-123's latest-action-wins rule,
+considering both account-level and principal-level actions.
+
+### `icrc153_is_frozen_principal`
+
+Returns whether a given principal is currently frozen at the principal level.
+
+```
+icrc153_is_frozen_principal : (principal) -> (bool) query;
+```
+
+Returns `true` iff the most recent **principal-level** action for the given principal was a freeze.
+Does not consider account-level actions.
+
 ## Effective Freeze Model (Clarification)
 
 ICRC-153 adopts the **latest-action-wins** rule defined in ICRC-123:
@@ -548,7 +565,7 @@ The caller invokes:
 
 ```
 icrc153_freeze_account({
-  account         = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
+  account         = [principal "ryjl3-tyaaa-aaaaa-aaaba-cai"];
   created_at_time = 1_753_500_100_000_000_000 : nat64;
   reason          = ?"Fraud investigation hold";
 })
@@ -563,16 +580,16 @@ variant {
   Map = vec {
     record { "btype"; variant { Text = "123freezeaccount" } };
     record { "phash"; variant { Blob = blob "\12\34\56\78\9a\bc\de\f0\01\23\45\67\89\ab\cd\ef\10\32\54\76\98\ba\dc\fe\11\22\33\44\55\66\77\88" } };
-    record { "ts";    variant { Nat64 = 1_753_500_101_000_000_000 : nat64 } };
+    record { "ts";    variant { Nat = 1_753_500_101_000_000_000 : nat } };
     record {
       "tx";
       variant {
         Map = vec {
           record { "mthd";    variant { Text = "153freeze_account" } };
           record { "account"; variant { Array = vec {
-            variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
+            variant { Blob = blob "\00\00\00\00\00\00\00\02\01\01" }
           } } };
-          record { "ts";      variant { Nat64 = 1_753_500_100_000_000_000 : nat64 } };
+          record { "ts";      variant { Nat = 1_753_500_100_000_000_000 : nat } };
           record { "caller";  variant { Blob  = blob "\00\00\00\00\02\30\02\17\01\01" } };
           record { "reason";  variant { Text  = "Fraud investigation hold" } };
         }
@@ -588,7 +605,7 @@ The block records the method (`mthd = "153freeze_account"`), the account being f
 The caller invokes:
 ```
 icrc153_unfreeze_account({
-  account         = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
+  account         = [principal "ryjl3-tyaaa-aaaaa-aaaba-cai"];
   created_at_time = 1_753_500_200_000_000_000 : nat64;
   reason          = ?"Lift compliance hold";
 })
@@ -607,7 +624,7 @@ variant {
         Map = vec {
           record { "mthd";    variant { Text = "153unfreeze_account" } };
           record { "account"; variant { Array = vec {
-            variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
+            variant { Blob = blob "\00\00\00\00\00\00\00\02\01\01" }
           } } };
           record { "ts";      variant { Nat  = 1_753_500_200_000_000_000 : nat } };
           record { "caller";  variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };
@@ -624,7 +641,7 @@ variant {
 The caller invokes:
 ```
 icrc153_freeze_principal({
-  principal       = principal "abcd0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+  principal       = principal "uf6dk-hyaaa-aaaaq-qaaaq-cai";
   created_at_time = 1_753_600_000_000_000_000 : nat64;
   reason          = ?"KYC review";
 })
@@ -642,7 +659,7 @@ variant {
       variant {
         Map = vec {
           record { "mthd";      variant { Text = "153freeze_principal" } };
-          record { "principal"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" } };
+          record { "principal"; variant { Blob = blob "\00\00\00\00\02\10\00\01\01\01" } };
           record { "ts";        variant { Nat  = 1_753_600_000_000_000_000 : nat } };
           record { "caller";    variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };
           record { "reason";    variant { Text = "KYC review" } };
@@ -658,7 +675,7 @@ The caller invokes:
 
 ```
 icrc153_unfreeze_principal({
-  principal       = principal "abcd0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+  principal       = principal "uf6dk-hyaaa-aaaaq-qaaaq-cai";
   created_at_time = 1_753_600_500_000_000_000 : nat64;
   reason          = ?"KYC cleared";
 })
@@ -677,7 +694,7 @@ variant {
       variant {
         Map = vec {
           record { "mthd";      variant { Text = "153unfreeze_principal" } };
-          record { "principal"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" } };
+          record { "principal"; variant { Blob = blob "\00\00\00\00\02\10\00\01\01\01" } };
           record { "ts";        variant { Nat  = 1_753_600_500_000_000_000 : nat } };
           record { "caller";    variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };
           record { "reason";    variant { Text = "KYC cleared" } };

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -163,7 +163,6 @@ type UnfreezeAccountArgs = record {
 type UnfreezeAccountError = variant {
   Unauthorized : text;
   InvalidAccount : text;
-  NotFrozen : text;                  // account is not currently frozen
   Duplicate : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text };
 };
@@ -191,16 +190,16 @@ icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (variant { Ok : nat; Err : U
 - The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
 - If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
-**Error cases (normative)**  
-- `Unauthorized` — caller not permitted.  
-- `InvalidAccount` — malformed or disallowed account.  
-- `NotFrozen` — account is not currently frozen.  
-- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+**Error cases (normative)**
+- `Unauthorized` — caller not permitted.
+- `InvalidAccount` — malformed or disallowed account.
+- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.
 - `GenericError { error_code, message }` — any other failure preventing a valid block.
 
-**Clarifications**  
-- The `tx` field uses **`ts`** for the caller-supplied timestamp (`created_at_time`).  
-- Optional fields **MUST be omitted** from `tx` if not supplied.  
+**Clarifications**
+- The call MUST succeed even if the account is not currently frozen at account level. Under ICRC-123's latest-action-wins rule, recording an unfreeze block can lift freeze blocks at other levels (e.g., account-level freezes lifted by a principal unfreeze).
+- The `tx` field uses **`ts`** for the caller-supplied timestamp (`created_at_time`).
+- Optional fields **MUST be omitted** from `tx` if not supplied.
 - Representation-independent hashing (ICRC-3) applies; field presence and value determine hash, not field order.
 
 #### Canonical `tx` Mapping (normative)
@@ -299,7 +298,6 @@ type UnfreezePrincipalArgs = record {
 type UnfreezePrincipalError = variant {
   Unauthorized : text;
   InvalidPrincipal : text;
-  NotFrozen : text;                  // principal is not currently frozen
   Duplicate : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text };
 };
@@ -327,16 +325,16 @@ icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err
 - The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
 - If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
-**Error cases (normative)**  
-- `Unauthorized` — caller not permitted.  
-- `InvalidPrincipal` — malformed/invalid principal bytes.  
-- `NotFrozen` — principal is not currently frozen.  
-- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+**Error cases (normative)**
+- `Unauthorized` — caller not permitted.
+- `InvalidPrincipal` — malformed/invalid principal bytes.
+- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.
 - `GenericError { error_code, message }` — any other failure preventing a valid block.
 
-**Clarifications**  
-- The `tx` field uses **`ts`** for the caller-supplied timestamp (`created_at_time`).  
-- Optional fields **MUST be omitted** from `tx` if not supplied.  
+**Clarifications**
+- The call MUST succeed even if the principal is not currently frozen at principal level. Under ICRC-123's latest-action-wins rule, recording an unfreeze block can lift freeze blocks at other levels (e.g., account-level freezes lifted by a principal unfreeze).
+- The `tx` field uses **`ts`** for the caller-supplied timestamp (`created_at_time`).
+- Optional fields **MUST be omitted** from `tx` if not supplied.
 - Representation-independent hashing (ICRC-3) applies; field presence and value determine hash, not field order.
 
 #### Canonical `tx` Mapping (normative)

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -318,10 +318,10 @@ freeze state. These queries do **not** produce blocks and are required for
 wallets, explorers, and auditors to efficiently enumerate frozen entities and
 perform quick checks.
 
-All results reflect the ledger’s state **at the time the query is executed**.
+All results reflect the ledger’s state **at the time the query is executed**. These queries are read-only and do not produce blocks.
 
 
-### `icrc147_list_frozen_accounts`
+### `icrc153_list_frozen_accounts`
 
 Lexicographically paginated listing of currently frozen **accounts**.
 
@@ -339,7 +339,7 @@ type FrozenAccountsResponse = record {
     has_more : bool;
 };
 
-icrc147_list_frozen_accounts : (FrozenAccountsRequest) -> (FrozenAccountsResponse) query;
+icrc153_list_frozen_accounts : (FrozenAccountsRequest) -> (FrozenAccountsResponse) query;
 ```
 
 
@@ -367,7 +367,7 @@ This matches the natural `Value::Array`/`Blob` bytewise ordering implied by ICRC
 - Implementations SHOULD enforce reasonable upper bounds for `max_results` to avoid excessive responses.
 - Results are a **point-in-time snapshot**; concurrent freezes/unfreezes may affect subsequent pages.
 
-### `icrc147_list_frozen_principals`
+### `icrc153_list_frozen_principals`
 
 Lexicographically paginated listing of currently frozen **principals**.
 
@@ -385,7 +385,7 @@ type FrozenPrincipalsResponse = record {
     has_more : bool;
 };
 
-icrc147_list_frozen_principals : (FrozenPrincipalsRequest) -> (FrozenPrincipalsResponse) query;
+icrc153_list_frozen_principals : (FrozenPrincipalsRequest) -> (FrozenPrincipalsResponse) query;
 ```
 
 #### Semantics
@@ -415,26 +415,26 @@ ICRC-153 adopts a **compositional freeze rule** consistent with ICRC-123:
 
 ### Implications for Queries
 
-- `icrc147_list_frozen_accounts`  
+- `icrc153_list_frozen_accounts`  
   Returns **only accounts frozen directly** (i.e., via account-level freezes).  
   It does **not** expand principal-level freezes into per-account entries.
 
-- `icrc147_list_frozen_principals`  
+- `icrc153_list_frozen_principals`  
   Returns **principals** that are frozen. Any account owned by a listed principal is
   *effectively frozen* by composition, even if it does not appear in the account list.
 
-- `icrc147_is_frozen_account(account)` MUST return `true` if the account is directly frozen
+- `icrc153_is_frozen_account(account)` MUST return `true` if the account is directly frozen
   **or** if `is_frozen_principal(account.owner)` is `true`.
 
-- `icrc147_is_frozen_principal(principal)` returns whether the **principal-level** freeze is active.
+- `icrc153_is_frozen_principal(principal)` returns whether the **principal-level** freeze is active.
 
 ### Integrator Guidance
 
 To determine whether a given account is currently frozen, integrators MUST either:
-- call `icrc147_is_frozen_account(account)`, or
+- call `icrc153_is_frozen_account(account)`, or
 - check both lists and apply the compositional rule:
-  1) see if `account` appears in `icrc147_list_frozen_accounts`, or
-  2) see if `account.owner` appears in `icrc147_list_frozen_principals`.
+  1) see if `account` appears in `icrc153_list_frozen_accounts`, or
+  2) see if `account.owner` appears in `icrc153_list_frozen_principals`.
 
 This approach avoids large state updates when freezing/unfreezing principals with many accounts,
 while providing a clear, deterministic interpretation of the effective freeze state.

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -100,7 +100,8 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 - On failure: `variant { Err : FreezeAccountError }`.
 
 **Deduplication & idempotency**  
-- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- `created_at_time` is required (not optional) because deduplication is always mandatory for privileged operations — accidental duplicate freeze/unfreeze actions must be prevented regardless of caller intent.  
+- The ledger **MUST** perform deduplication using `created_at_time` and any implementation-defined inputs.  
 - If a duplicate is detected, **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
 **Error cases (normative)**  
@@ -172,7 +173,8 @@ icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (variant { Ok : nat; Err : U
 - On failure: `variant { Err : UnfreezeAccountError }`.
 
 **Deduplication & idempotency**  
-- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- `created_at_time` is required (not optional) because deduplication is always mandatory for privileged operations — accidental duplicate freeze/unfreeze actions must be prevented regardless of caller intent.  
+- The ledger **MUST** perform deduplication using `created_at_time` and any implementation-defined inputs.  
 - If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
 **Error cases (normative)**
@@ -243,7 +245,8 @@ icrc153_freeze_principal : (FreezePrincipalArgs) -> (variant { Ok : nat; Err : F
 - On failure: `variant { Err : FreezePrincipalError }`.
 
 **Deduplication & idempotency**  
-- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- `created_at_time` is required (not optional) because deduplication is always mandatory for privileged operations — accidental duplicate freeze/unfreeze actions must be prevented regardless of caller intent.  
+- The ledger **MUST** perform deduplication using `created_at_time` and any implementation-defined inputs.  
 - If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
 **Error cases (normative)**  
@@ -315,7 +318,8 @@ icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err
 - On failure: `variant { Err : UnfreezePrincipalError }`.
 
 **Deduplication & idempotency**  
-- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- `created_at_time` is required (not optional) because deduplication is always mandatory for privileged operations — accidental duplicate freeze/unfreeze actions must be prevented regardless of caller intent.  
+- The ledger **MUST** perform deduplication using `created_at_time` and any implementation-defined inputs.  
 - If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
 **Error cases (normative)**
@@ -390,7 +394,9 @@ All results reflect the ledger’s state **at the time the query is executed**. 
 
 ### `icrc153_list_frozen_accounts`
 
-Lexicographically paginated listing of currently frozen **accounts**.
+Lexicographically paginated listing of accounts whose most recent **account-level** action was a freeze.
+
+> ⚠️ **Not exhaustive of effectively frozen accounts.** This method only returns accounts frozen by `123freezeaccount`/`123unfreezeaccount` blocks. Accounts that are effectively frozen solely because their owner principal is frozen (via `123freezeprincipal`) are **not** listed here. To determine whether a specific account is effectively frozen (considering both account- and principal-level freezes), use `icrc153_is_frozen_account`. To enumerate principal-level freezes, use `icrc153_list_frozen_principals`. See **Effective Freeze Model** below.
 
 #### Arguments
 ```
@@ -436,7 +442,9 @@ This matches the natural `Value::Array`/`Blob` bytewise ordering implied by ICRC
 
 ### `icrc153_list_frozen_principals`
 
-Lexicographically paginated listing of currently frozen **principals**.
+Lexicographically paginated listing of principals whose most recent **principal-level** action was a freeze.
+
+> ⚠️ **Returns principal-level freezes only.** This method does not enumerate accounts that are effectively frozen because of a principal-level freeze; it returns the principals themselves. To check whether a specific principal is effectively frozen, use `icrc153_is_frozen_principal`. See **Effective Freeze Model** below.
 
 #### Arguments
 ```

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -350,13 +350,12 @@ icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err
 - **Effect on operations**: The precise effects of freeze/unfreeze (which operations are blocked, account vs principal precedence, etc.) are entirely defined by ICRC-123. ICRC-153 only defines the interface and canonical `tx` mapping.
 - **No fees**: ICRC-153 calls do not involve fees; ledgers MUST NOT include a top-level `fee` field for these blocks.
 
-## Reporting Compliance
+## Compliance Reporting
 
 ### Supported Standards
 
 Ledgers implementing ICRC-153 MUST indicate compliance through the
-`icrc1_supported_standards` and `icrc10_supported_standards` methods by
-including:
+`icrc10_supported_standards` method by including in its output:
 
 ```candid
 vec {
@@ -366,6 +365,9 @@ vec {
     }
 }
 ```
+
+Ledgers that also implement ICRC-1 MUST additionally include this entry in
+the output of `icrc1_supported_standards`.
 
 ### Supported Block Types
 

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -394,9 +394,14 @@ All results reflect the ledger’s state **at the time the query is executed**. 
 
 ### `icrc153_list_frozen_accounts`
 
-Lexicographically paginated listing of accounts whose most recent **account-level** action was a freeze.
+Lexicographically paginated listing of accounts that are **currently effectively frozen at the account level** — i.e., an account `acc` is listed iff both of the following hold:
 
-> ⚠️ **Not exhaustive of effectively frozen accounts.** This method only returns accounts frozen by `123freezeaccount`/`123unfreezeaccount` blocks. Accounts that are effectively frozen solely because their owner principal is frozen (via `123freezeprincipal`) are **not** listed here. To determine whether a specific account is effectively frozen (considering both account- and principal-level freezes), use `icrc153_is_frozen_account`. To enumerate principal-level freezes, use `icrc153_list_frozen_principals`. See **Effective Freeze Model** below.
+1. The most recent `123freezeaccount`/`123unfreezeaccount` block targeting `acc` is a freeze, and
+2. No `123unfreezeprincipal` block on `acc.owner` is more recent than the account-level freeze identified in (1).
+
+Every account returned by this method **MUST** satisfy `icrc153_is_frozen_account(acc) = true`.
+
+> ⚠️ **Not exhaustive of effectively frozen accounts.** Accounts that are effectively frozen *solely* because their owner principal is frozen (via `123freezeprincipal`, with no account-level freeze) are **not** listed here. To enumerate principal-level freezes, use `icrc153_list_frozen_principals`. To check whether a specific account is effectively frozen, use `icrc153_is_frozen_account`. See **Effective Freeze Model** below.
 
 #### Arguments
 ```
@@ -524,10 +529,13 @@ ICRC-153 adopts the **latest-action-wins** rule defined in ICRC-123:
 ### Implications for Queries
 
 - `icrc153_list_frozen_accounts`
-  Returns accounts whose most recent **account-level** action was a freeze.
-  It does **not** expand principal-level freezes into per-account entries, nor
-  does it exclude accounts that have been effectively unfrozen by a later
-  principal-level unfreeze.
+  Returns accounts that are effectively frozen **by an account-level freeze**:
+  the most recent `123freezeaccount`/`123unfreezeaccount` block targeting the
+  account is a freeze, **and** no later `123unfreezeprincipal` on the owner
+  has superseded it. It does **not** expand principal-level freezes into
+  per-account entries (so accounts frozen only via a principal-level freeze
+  are excluded), but every returned account is guaranteed to satisfy
+  `icrc153_is_frozen_account = true`.
 
 - `icrc153_list_frozen_principals`
   Returns principals whose most recent **principal-level** action was a freeze.
@@ -545,9 +553,11 @@ To determine whether a given account is currently frozen, integrators SHOULD
 call `icrc153_is_frozen_account(account)`, which applies the full
 latest-action-wins rule.
 
-Alternatively, integrators can reconstruct the effective status from the
-listing endpoints, but they MUST compare the block indices of the most recent
-account-level and principal-level actions rather than applying a simple OR.
+To enumerate every effectively frozen account, integrators MUST take the
+union of `icrc153_list_frozen_accounts` with the accounts owned by each
+principal returned by `icrc153_list_frozen_principals`. Both listing
+endpoints are individually sound (each entry is effectively frozen), but
+principal-level freezes are not expanded into per-account entries.
 
 
 ## Example: Freeze and Unfreeze — method calls and resulting blocks

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -14,7 +14,7 @@ ICRC-153 addresses this by standardizing four privileged methods that append can
 - `icrc153_freeze_account`, `icrc153_unfreeze_account`
 - `icrc153_freeze_principal`, `icrc153_unfreeze_principal`
 
-**Canonical `tx` mapping** with namespaced `op` values (`"153..."`), caller identity, and optional human-readable reason.
+**Canonical `tx` mapping** with namespaced `mthd` values (`"153..."`), caller identity, and optional human-readable reason.
 
 Recording uses **ICRC-123** block kinds (this standard does **not** add new block types).
 
@@ -27,8 +27,8 @@ Specifically, it defines:
 - **APIs** to freeze/unfreeze **accounts** and **principals**, callable only by authorized entities.
 - **Canonical `tx` mapping** rules ensuring deterministic block content and easy attribution/auditing.
 - **Use of ICRC-123 block kinds** to record these actions:
-  - `btype = "123freeze_account"`, `btype = "123unfreeze_account"`
-  - `btype = "123freeze_principal"`, `btype = "123unfreeze_principal"`
+  - `btype = "123freezeaccount"`, `btype = "123unfreezeaccount"`
+  - `btype = "123freezeprincipal"`, `btype = "123unfreezeprincipal"`
 - **Compliance reporting** through ICRC-10 methods.
 
 This enables wallets, explorers, and auditors to:
@@ -43,14 +43,14 @@ This standard does not introduce new block kinds.
 
 - **ICRC-3** — Block log format, hashing, certification, and canonical `tx` mapping rules.
 - **ICRC-123** — Defines the typed block kinds that ICRC-153 uses:
-  - `btype = "123freeze_account"`
-  - `btype = "123unfreeze_account"`
-  - `btype = "123freeze_principal"`
-  - `btype = "123unfreeze_principal"`
+  - `btype = "123freezeaccount"`
+  - `btype = "123unfreezeaccount"`
+  - `btype = "123freezeprincipal"`
+  - `btype = "123unfreezeprincipal"`
 
 A ledger implementing ICRC-153 MUST:
 - Emit the appropriate **ICRC-123** block on each successful call.
-- Populate `tx.op` with namespaced values **introduced by this standard**:
+- Populate `tx.mthd` with namespaced values **introduced by this standard**:
   `"153freeze_account"`, `"153unfreeze_account"`, `"153freeze_principal"`, `"153unfreeze_principal"`.
 
 
@@ -73,7 +73,7 @@ This standard inherits core conventions from **ICRC-3** (block log format, Value
 
 - **Blocks & Parent Hash**  
   All blocks created by this API use the ICRC-123 block kinds  
-  (`btype = "123freeze_account"`, `"123unfreeze_account"`, `"123freeze_principal"`, `"123unfreeze_principal"`).  
+  (`btype = "123freezeaccount"`, `"123unfreezeaccount"`, `"123freezeprincipal"`, `"123unfreezeprincipal"`).  
   Standard metadata (`ts`, `phash`) follows ICRC-3.
 
 
@@ -110,7 +110,7 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 
 **Effect (on success, non-retroactive)**  
 - Mark the specified `account` as **frozen** according to ICRC-123 semantics.  
-- Append a new block with `btype = "123freeze_account"`.  
+- Append a new block with `btype = "123freezeaccount"`.  
 - The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings).  
 - On success, return the index of the newly appended block.
 
@@ -137,7 +137,7 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 
 | Field             | Type (ICRC-3 `Value`) | Source / Encoding Rule |
 |-------------------|------------------------|-------------------------|
-| `op`              | `Text`                 | **Constant** `"153freeze_account"`. |
+| `mthd`            | `Text`                 | **Constant** `"153freeze_account"`. |
 | `account`         | `Array` (Account)      | From `FreezeAccountArgs.account`, encoded as ICRC-3 Account. |
 | `created_at_time` | `Nat`                  | From `FreezeAccountArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
 | `caller`          | `Blob`                 | Principal of the caller (raw bytes). |
@@ -179,7 +179,7 @@ icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (variant { Ok : nat; Err : U
 
 **Effect (on success, non-retroactive)**  
 - Mark the specified `account` as **unfrozen** according to ICRC-123 semantics.  
-- Append a new block with `btype = "123unfreeze_account"`.  
+- Append a new block with `btype = "123unfreezeaccount"`.  
 - The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings), with `ts` derived from `created_at_time`.  
 - On success, return the index of the newly appended block.
 
@@ -207,7 +207,7 @@ icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (variant { Ok : nat; Err : U
 
 | Field | Type (ICRC-3 `Value`) | Source / Encoding Rule |
 |---|---|---|
-| `op` | `Text` | **Constant** `"153unfreeze_account"`. |
+| `mthd` | `Text` | **Constant** `"153unfreeze_account"`. |
 | `account` | `Array` (Account) | From `UnfreezeAccountArgs.account`. |
 | `ts` | `Nat` | From `UnfreezeAccountArgs.created_at_time`. |
 | `caller` | `Blob` | Principal of the caller. |
@@ -246,7 +246,7 @@ icrc153_freeze_principal : (FreezePrincipalArgs) -> (variant { Ok : nat; Err : F
 
 **Effect (on success, non-retroactive)**  
 - Mark the specified `principal` as **frozen** (scope and effect per ICRC-123), impacting its accounts via composition.  
-- Append a new block with `btype = "123freeze_principal"`.  
+- Append a new block with `btype = "123freezeprincipal"`.  
 - The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings), with `ts` derived from `created_at_time`.  
 - On success, return the index of the newly appended block.
 
@@ -274,7 +274,7 @@ icrc153_freeze_principal : (FreezePrincipalArgs) -> (variant { Ok : nat; Err : F
 
 | Field | Type (ICRC-3 `Value`) | Source / Encoding Rule |
 |---|---|---|
-| `op` | `Text` | **Constant** `"153freeze_principal"`. |
+| `mthd` | `Text` | **Constant** `"153freeze_principal"`. |
 | `principal` | `Blob` | From `FreezePrincipalArgs.principal` (principal bytes). |
 | `ts` | `Nat` | From `FreezePrincipalArgs.created_at_time`. |
 | `caller` | `Blob` | Principal of the caller. |
@@ -315,7 +315,7 @@ icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err
 
 **Effect (on success, non-retroactive)**  
 - Mark the specified `principal` as **unfrozen** (lifting restrictions per ICRC-123).  
-- Append a new block with `btype = "123unfreeze_principal"`.  
+- Append a new block with `btype = "123unfreezeprincipal"`.  
 - The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings), with `ts` derived from `created_at_time`.  
 - On success, return the index of the newly appended block.
 
@@ -343,7 +343,7 @@ icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err
 
 | Field | Type (ICRC-3 `Value`) | Source / Encoding Rule |
 |---|---|---|
-| `op` | `Text` | **Constant** `"153unfreeze_principal"`. |
+| `mthd` | `Text` | **Constant** `"153unfreeze_principal"`. |
 | `principal` | `Blob` | From `UnfreezePrincipalArgs.principal`. |
 | `ts` | `Nat` | From `UnfreezePrincipalArgs.created_at_time`. |
 | `caller` | `Blob` | Principal of the caller. |
@@ -378,8 +378,8 @@ variant { Vec = vec {
 
 ICRC-153 extends ICRC-123 and does not introduce new block kinds.
 Accordingly, ledgers implementing ICRC-153 MUST already advertise support for the
-relevant ICRC-123 block kinds (e.g., `123freeze_account`, `123unfreeze_account`,
-`123freeze_principal`, `123unfreeze_principal`) as required by ICRC-123.
+relevant ICRC-123 block kinds (e.g., `123freezeaccount`, `123unfreezeaccount`,
+`123freezeprincipal`, `123unfreezeprincipal`) as required by ICRC-123.
 No additional block types need to be reported.
 
 
@@ -543,19 +543,19 @@ icrc153_freeze_account({
 
 #### Resulting block
 
-This call rsults in a block with btype="122freeze_account" and the following contents:
+This call results in a block with `btype = "123freezeaccount"` and the following contents:
 
 ```
 variant {
   Map = vec {
-    record { "btype"; variant { Text = "123freeze_account" } };
+    record { "btype"; variant { Text = "123freezeaccount" } };
     record { "phash"; variant { Blob = blob "\12\34\56\78\9a\bc\de\f0\01\23\45\67\89\ab\cd\ef\10\32\54\76\98\ba\dc\fe\11\22\33\44\55\66\77\88" } };
     record { "ts";    variant { Nat64 = 1_753_500_101_000_000_000 : nat64 } };
     record {
       "tx";
       variant {
         Map = vec {
-          record { "op";      variant { Text = "153freeze_account" } };
+          record { "mthd";    variant { Text = "153freeze_account" } };
           record { "account"; variant { Array = vec {
             variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
           } } };
@@ -569,12 +569,12 @@ variant {
 };
 ```
 
-The block records the operation (op = "153freeze_account"), the account being frozen (account), the caller-supplied timestamp (ts), the caller’s principal (caller), and the optional reason. The account is shown as a principal literal in the call, but stored canonically as a Blob in the block.
+The block records the method (`mthd = "153freeze_account"`), the account being frozen (`account`), the caller-supplied timestamp (`ts`), the caller’s principal (`caller`), and the optional `reason`. The account is shown as a principal literal in the call, but stored canonically as a Blob in the block.
 
 #### Call
 The caller invokes:
 ```
-iicrc153_unfreeze_account({
+icrc153_unfreeze_account({
   account         = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
   created_at_time = 1_753_500_200_000_000_000 : nat64;
   reason          = ?"Lift compliance hold";
@@ -585,14 +585,14 @@ iicrc153_unfreeze_account({
 ```
 variant {
   Map = vec {
-    record { "btype"; variant { Text = "123unfreeze_account" } };
+    record { "btype"; variant { Text = "123unfreezeaccount" } };
     record { "phash"; variant { Blob = blob "\9f\aa\10\44\20\19\77\35\c2\9e\00\41\aa\cd\12\ef\04\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88" } }; // illustrative
     record { "ts";    variant { Nat = 1_753_500_201_000_000_000 : nat } };
     record {
       "tx";
       variant {
         Map = vec {
-          record { "op";      variant { Text = "153unfreeze_account" } };
+          record { "mthd";    variant { Text = "153unfreeze_account" } };
           record { "account"; variant { Array = vec {
             variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
           } } };
@@ -621,14 +621,14 @@ icrc153_freeze_principal({
 ```
 variant {
   Map = vec {
-    record { "btype"; variant { Text = "123freeze_principal" } };
+    record { "btype"; variant { Text = "123freezeprincipal" } };
     record { "phash"; variant { Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99\01\23\45\67\89\ab\cd\ef\10\32\54\76\98\ba\dc\fe" } }; // illustrative
     record { "ts";    variant { Nat = 1_753_600_001_000_000_000 : nat } };
     record {
       "tx";
       variant {
         Map = vec {
-          record { "op";        variant { Text = "153freeze_principal" } };
+          record { "mthd";      variant { Text = "153freeze_principal" } };
           record { "principal"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" } };
           record { "ts";        variant { Nat  = 1_753_600_000_000_000_000 : nat } };
           record { "caller";    variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };
@@ -656,14 +656,14 @@ icrc153_unfreeze_principal({
 ```
 variant {
   Map = vec {
-    record { "btype"; variant { Text = "123unfreeze_principal" } };
+    record { "btype"; variant { Text = "123unfreezeprincipal" } };
     record { "phash"; variant { Blob = blob "\fe\dc\ba\98\76\54\32\10\ef\cd\ab\89\67\45\23\01\99\88\77\66\55\44\33\22\11\00\ff\ee\dd\cc\bb\aa" } }; // illustrative
     record { "ts";    variant { Nat = 1_753_600_501_000_000_000 : nat } };
     record {
       "tx";
       variant {
         Map = vec {
-          record { "op";        variant { Text = "153unfreeze_principal" } };
+          record { "mthd";      variant { Text = "153unfreeze_principal" } };
           record { "principal"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" } };
           record { "ts";        variant { Nat  = 1_753_600_500_000_000_000 : nat } };
           record { "caller";    variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -1,0 +1,311 @@
+# ICRC-153: Privileged Freeze & Unfreeze API
+
+| Status |
+|:------:|
+| Draft  |
+
+## Introduction & Motivation
+
+Operational and regulatory requirements for custodial tokens, stablecoins, and RWA ledgers often include the ability to **freeze** (temporarily disable) or **unfreeze** transfer activity for specific **accounts** or for all accounts belonging to a **principal**. Absent a standard interface, integrators cannot reliably determine whether funds are movable, nor attribute freezes to clear, on-chain actions.
+
+ICRC-153 addresses this by standardizing four privileged methods that append canonical, typed blocks (as defined in **ICRC-123**) and by defining the canonical mapping from method inputs to the `tx` field for those blocks.
+
+**Privileged methods (authorized principals only):**
+- `icrc153_freeze_account`, `icrc153_unfreeze_account`
+- `icrc153_freeze_principal`, `icrc153_unfreeze_principal`
+
+**Canonical `tx` mapping** with namespaced `op` values (`"153..."`), caller identity, and optional human-readable reason.
+
+Recording uses **ICRC-123** block kinds (this standard does **not** add new block types).
+
+## Overview
+
+ICRC-153 standardizes privileged freeze/unfreeze controls for ICRC ledgers.
+
+Specifically, it defines:
+
+- **APIs** to freeze/unfreeze **accounts** and **principals**, callable only by authorized entities.
+- **Canonical `tx` mapping** rules ensuring deterministic block content and easy attribution/auditing.
+- **Use of ICRC-123 block kinds** to record these actions:
+  - `btype = "123freeze_account"`, `btype = "123unfreeze_account"`
+  - `btype = "123freeze_principal"`, `btype = "123unfreeze_principal"`
+- **Compliance reporting** through ICRC-10 methods.
+
+This enables wallets, explorers, and auditors to:
+
+- Determine, on-chain, whether an account or a principal is currently frozen.
+- Attribute actions to a specific authorized caller and (optionally) a recorded reason.
+- Interoperate across ledgers that implement the same API and block semantics.
+
+## Dependencies
+
+This standard does not introduce new block kinds.
+
+- **ICRC-3** — Block log format, hashing, certification, and canonical `tx` mapping rules.
+- **ICRC-123** — Defines the typed block kinds that ICRC-153 uses:
+  - `btype = "123freeze_account"`
+  - `btype = "123unfreeze_account"`
+  - `btype = "123freeze_principal"`
+  - `btype = "123unfreeze_principal"`
+
+A ledger implementing ICRC-153 MUST:
+- Emit the appropriate **ICRC-123** block on each successful call.
+- Populate `tx.op` with namespaced values **introduced by this standard**:
+  `"153freeze_account"`, `"153unfreeze_account"`, `"153freeze_principal"`, `"153unfreeze_principal"`.
+
+## Methods
+
+### `icrc153_freeze_account`
+
+Freeze a specific **account** (owner + optional subaccount). Once frozen, operations affected by ICRC-123’s semantics MUST be rejected until unfrozen.
+
+#### Arguments
+
+```
+type FreezeAccountArgs = record {
+  account         : Account;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type FreezeAccountError = variant {
+  Unauthorized : text;               // caller not permitted
+  InvalidAccount : text;             // malformed or disallowed account
+  AlreadyFrozen : text;              // account is already frozen
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text };
+};
+
+icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : FreezeAccountError });
+```
+#### Semantics
+
+- Marks the account as **frozen** according to ICRC-123 semantics.  
+- Appends a block of type `123freeze_account`.  
+- On success, returns the **index of the created block**.  
+- On failure, returns an appropriate error.  
+- Semantics are consistent with the freeze semantics defined by ICRC-123.  
+
+#### Return Values
+
+On success:  
+
+- `variant { Ok : nat }` — the created block index.  
+
+On failure:  
+
+- `variant { Err : FreezeAccountError }`.  
+
+#### Canonical `tx` Mapping
+
+A successful call to `icrc153_freeze_account` produces a `123freeze_account` block.  
+The `tx` field is derived as follows:
+
+- `op      = "153freeze_account"`  
+- `account = FreezeAccountArgs.account`  
+- `ts      = FreezeAccountArgs.created_at_time`  
+- `caller  = caller_principal (as Blob)`  
+- `reason  = FreezeAccountArgs.reason` (if provided)  
+
+Optional fields MUST be omitted if not supplied.  
+
+
+### `icrc153_unfreeze_account`
+
+Unfreeze a specific account previously frozen.
+
+#### Arguments
+
+```
+type UnfreezeAccountArgs = record {
+  account         : Account;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type UnfreezeAccountError = variant {
+  Unauthorized : text;
+  InvalidAccount : text;
+  NotFrozen : text;                  // account is not currently frozen
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text };
+};
+
+icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (variant { Ok : nat; Err : UnfreezeAccountError });
+```
+
+#### Semantics
+
+- Marks account as **unfrozen** according to ICRC-123 semantics.  
+- Appends a block of type `123unfreeze_account`.  
+- On success, returns the **index of the created block**.  
+- On failure, returns an appropriate error.  
+- Semantics are consistent with the unfreeze semantics defined by ICRC-123.  
+
+#### Return Values
+
+On success:  
+
+- `variant { Ok : nat }` — the created block index.  
+
+On failure:  
+
+- `variant { Err : UnfreezeAccountError }`.  
+
+#### Canonical `tx` Mapping
+
+A successful call to `icrc153_unfreeze_account` produces a `123unfreeze_account` block.  
+The `tx` field is derived as follows:
+
+- `op      = "153unfreeze_account"`  
+- `account = UnfreezeAccountArgs.account`  
+- `ts      = UnfreezeAccountArgs.created_at_time`  
+- `caller  = caller_principal (as Blob)`  
+- `reason  = UnfreezeAccountArgs.reason` (if provided)  
+
+Optional fields MUST be omitted if not supplied.
+
+
+### `icrc153_freeze_principal`
+
+Freeze all accounts belonging to a given principal per ICRC-123 semantics.
+
+#### Arguments
+
+```
+type FreezePrincipalArgs = record {
+  principal       : principal;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type FreezePrincipalError = variant {
+  Unauthorized : text;
+  InvalidPrincipal : text;
+  AlreadyFrozen : text;              // principal is already frozen at scope defined by ICRC-123
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text };
+};
+
+icrc153_freeze_principal : (FreezePrincipalArgs) -> (variant { Ok : nat; Err : FreezePrincipalError });
+```
+
+#### Semantics
+
+- Marks the **principal** as frozen (scope per ICRC-123), affecting its accounts.  
+- Appends a block of type `123freeze_principal`.  
+- On success, returns the **index of the created block**.  
+- On failure, returns an appropriate error.  
+- Semantics are consistent with the freeze semantics defined by ICRC-123.  
+
+#### Return Values
+
+On success:  
+
+- `variant { Ok : nat }` — the created block index.  
+
+On failure:  
+
+- `variant { Err : FreezePrincipalError }`.  
+
+#### Canonical `tx` Mapping
+
+A successful call to `icrc153_freeze_principal` produces a `123freeze_principal` block.  
+The `tx` field is derived as follows:
+
+- `op        = "153freeze_principal"`  
+- `principal = caller-supplied principal (as Blob)`  
+  (in ICRC-3 Value, principals are encoded as `Blob`)  
+- `ts        = FreezePrincipalArgs.created_at_time`  
+- `caller    = caller_principal (as Blob)`  
+- `reason    = FreezePrincipalArgs.reason` (if provided)  
+
+Optional fields MUST be omitted if not supplied.  
+
+
+### `icrc153_unfreeze_principal`
+
+Lift the freeze affecting a principal (and the scope of accounts specified by ICRC-123).
+
+#### Arguments
+
+```
+type UnfreezePrincipalArgs = record {
+  principal       : principal;
+  created_at_time : nat64;
+  reason          : opt text;
+};
+
+type UnfreezePrincipalError = variant {
+  Unauthorized : text;
+  InvalidPrincipal : text;
+  NotFrozen : text;                  // principal is not currently frozen
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text };
+};
+
+icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err : UnfreezePrincipalError });
+```
+
+#### Semantics
+
+- Marks the principal as **unfrozen**, lifting restrictions according to ICRC-123 semantics.  
+- Appends a block of type `123unfreeze_principal`.  
+- On success, returns the **index of the created block**.  
+- On failure, returns an appropriate error.  
+- Semantics are consistent with the unfreeze semantics defined by ICRC-123.  
+
+#### Return Values
+
+On success:  
+
+- `variant { Ok : nat }` — the created block index.  
+
+On failure:  
+
+- `variant { Err : UnfreezePrincipalError }`.  
+
+#### Canonical `tx` Mapping
+
+A successful call to `icrc153_unfreeze_principal` produces a `123unfreeze_principal` block.  
+The `tx` field is derived as follows:
+
+- `op        = "153unfreeze_principal"`  
+- `principal = UnfreezePrincipalArgs.principal` (encoded as Blob per ICRC-3 Value)  
+- `ts        = UnfreezePrincipalArgs.created_at_time`  
+- `caller    = caller_principal (as Blob)`  
+- `reason    = UnfreezePrincipalArgs.reason` (if provided)  
+
+Optional fields MUST be omitted if not supplied.
+
+## Notes on Semantics & Scope
+
+- **Authorizations**: Each method is privileged; ledgers MUST restrict these calls to authorized principals (policy/RBAC is ledger-defined or standardized separately).
+- **Deduplication**: `created_at_time` is used for replay protection/deduplication (as in ICRC-1). Duplicate calls MUST return `Duplicate { duplicate_of = <block_index> }` and MUST NOT produce a new block.
+- **Effect on operations**: The precise effects of freeze/unfreeze (which operations are blocked, account vs principal precedence, etc.) are entirely defined by ICRC-123. ICRC-153 only defines the interface and canonical `tx` mapping.
+- **No fees**: ICRC-153 calls do not involve fees; ledgers MUST NOT include a top-level `fee` field for these blocks.
+
+## Reporting Compliance
+
+### Supported Standards
+
+Ledgers implementing ICRC-153 MUST indicate compliance through the
+`icrc1_supported_standards` and `icrc10_supported_standards` methods by
+including:
+
+```
+variant { Vec = vec {
+  record {
+    "name"; variant { Text = "ICRC-153" };
+    "url";  variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-153.md" };
+  }
+}};
+```
+
+### Supported Block Types
+
+ICRC-153 extends ICRC-123 and does not introduce new block kinds.
+Accordingly, ledgers implementing ICRC-153 MUST already advertise support for the
+relevant ICRC-123 block kinds (e.g., `123freeze_account`, `123unfreeze_account`,
+`123freeze_principal`, `123unfreeze_principal`) as required by ICRC-123.
+No additional block types need to be reported.

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -442,9 +442,7 @@ This matches the natural `Value::Array`/`Blob` bytewise ordering implied by ICRC
 
 ### `icrc153_list_frozen_principals`
 
-Lexicographically paginated listing of principals whose most recent **principal-level** action was a freeze.
-
-> ⚠️ **Returns principal-level freezes only.** This method does not enumerate accounts that are effectively frozen because of a principal-level freeze; it returns the principals themselves. To check whether a specific principal is effectively frozen, use `icrc153_is_frozen_principal`. See **Effective Freeze Model** below.
+Lexicographically paginated listing of currently frozen **principals**.
 
 #### Arguments
 ```

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -53,6 +53,30 @@ A ledger implementing ICRC-153 MUST:
 - Populate `tx.op` with namespaced values **introduced by this standard**:
   `"153freeze_account"`, `"153unfreeze_account"`, `"153freeze_principal"`, `"153unfreeze_principal"`.
 
+
+## Common Elements
+
+This standard inherits core conventions from **ICRC-3** (block log format, Value encoding, hashing, certification) and **ICRC-123** (typed block kinds and freeze/unfreeze semantics).
+
+- **Accounts**  
+  Encoded as ICRC-3 `Value` `variant { Array = vec { V1 [, V2] } }` where  
+  `V1 = variant { Blob = <owner_principal_bytes> }` and optionally  
+  `V2 = variant { Blob = <32-byte_subaccount_bytes> }`.  
+  If no subaccount is provided, the array contains only the owner principal.
+
+- **Principals**  
+  Encoded as `variant { Blob = <principal_bytes> }`.
+
+- **Timestamps**  
+  Caller-supplied `created_at_time` is in **nanoseconds since Unix epoch**.  
+  Encoded as `Nat` in ICRC-3 `Value` and **MUST** fit in `nat64`.
+
+- **Blocks & Parent Hash**  
+  All blocks created by this API use the ICRC-123 block kinds  
+  (`btype = "123freeze_account"`, `"123unfreeze_account"`, `"123freeze_principal"`, `"123unfreeze_principal"`).  
+  Standard metadata (`ts`, `phash`) follows ICRC-3.
+
+
 ## Methods
 
 ### `icrc153_freeze_account`
@@ -80,34 +104,47 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 ```
 #### Semantics
 
-- Marks the account as **frozen** according to ICRC-123 semantics.  
-- Appends a block of type `123freeze_account`.  
-- On success, returns the **index of the created block**.  
-- On failure, returns an appropriate error.  
-- Semantics are consistent with the freeze semantics defined by ICRC-123.  
+**Authorization**  
+- The method **MUST** be callable only by a **controller** of the ledger or other explicitly authorized principals.  
+- Unauthorized calls **MUST** fail with `Unauthorized`.
 
-#### Return Values
+**Effect (on success, non-retroactive)**  
+- Mark the specified `account` as **frozen** according to ICRC-123 semantics.  
+- Append a new block with `btype = "123freeze_account"`.  
+- The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings).  
+- On success, return the index of the newly appended block.
 
-On success:  
+**Return value**  
+- On success: `variant { Ok : nat }`, where the `nat` is the index of the created block.  
+- On failure: `variant { Err : FreezeAccountError }`.
 
-- `variant { Ok : nat }` — the created block index.  
+**Deduplication & idempotency**  
+- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- If a duplicate is detected, **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
-On failure:  
+**Error cases (normative)**  
+- `Unauthorized` — caller not permitted.  
+- `InvalidAccount` — malformed or disallowed account (e.g., minting account, malformed principal/subaccount).  
+- `AlreadyFrozen` — account already frozen.  
+- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+- `GenericError { error_code, message }` — any other failure preventing a valid block.
 
-- `variant { Err : FreezeAccountError }`.  
 
-#### Canonical `tx` Mapping
+#### Canonical `tx` Mapping (normative)
 
-A successful call to `icrc153_freeze_account` produces a `123freeze_account` block.  
-The `tx` field is derived as follows:
+| Field             | Type (ICRC-3 `Value`) | Source / Encoding Rule |
+|-------------------|------------------------|-------------------------|
+| `op`              | `Text`                 | **Constant** `"153freeze_account"`. |
+| `account`         | `Array` (Account)      | From `FreezeAccountArgs.account`, encoded as ICRC-3 Account. |
+| `created_at_time` | `Nat`                  | From `FreezeAccountArgs.created_at_time` (ns since Unix epoch; **MUST** fit `nat64`). |
+| `caller`          | `Blob`                 | Principal of the caller (raw bytes). |
+| `reason`          | `Text` *(optional)*    | From `FreezeAccountArgs.reason` if provided; **omit** if absent. |
 
-- `op      = "153freeze_account"`  
-- `account = FreezeAccountArgs.account`  
-- `ts      = FreezeAccountArgs.created_at_time`  
-- `caller  = caller_principal (as Blob)`  
-- `reason  = FreezeAccountArgs.reason` (if provided)  
 
-Optional fields MUST be omitted if not supplied.  
+**Clarifications**  
+- Optional fields **MUST be omitted** from `tx` if not supplied.  
+
+
 
 
 ### `icrc153_unfreeze_account`

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -129,6 +129,9 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 - `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
 - `GenericError { error_code, message }` — any other failure preventing a valid block.
 
+**Clarifications**  
+- Optional fields **MUST be omitted** from `tx` if not supplied.  
+
 
 #### Canonical `tx` Mapping (normative)
 
@@ -140,9 +143,6 @@ icrc153_freeze_account : (FreezeAccountArgs) -> (variant { Ok : nat; Err : Freez
 | `caller`          | `Blob`                 | Principal of the caller (raw bytes). |
 | `reason`          | `Text` *(optional)*    | From `FreezeAccountArgs.reason` if provided; **omit** if absent. |
 
-
-**Clarifications**  
-- Optional fields **MUST be omitted** from `tx` if not supplied.  
 
 
 
@@ -173,34 +173,45 @@ icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (variant { Ok : nat; Err : U
 
 #### Semantics
 
-- Marks account as **unfrozen** according to ICRC-123 semantics.  
-- Appends a block of type `123unfreeze_account`.  
-- On success, returns the **index of the created block**.  
-- On failure, returns an appropriate error.  
-- Semantics are consistent with the unfreeze semantics defined by ICRC-123.  
+**Authorization**  
+- The method **MUST** be callable only by a **controller** of the ledger or other explicitly authorized principals.  
+- Unauthorized calls **MUST** fail with `Unauthorized`.
 
-#### Return Values
+**Effect (on success, non-retroactive)**  
+- Mark the specified `account` as **unfrozen** according to ICRC-123 semantics.  
+- Append a new block with `btype = "123unfreeze_account"`.  
+- The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings), with `ts` derived from `created_at_time`.  
+- On success, return the index of the newly appended block.
 
-On success:  
+**Return value**  
+- On success: `variant { Ok : nat }`, where the `nat` is the index of the created block.  
+- On failure: `variant { Err : UnfreezeAccountError }`.
 
-- `variant { Ok : nat }` — the created block index.  
+**Deduplication & idempotency**  
+- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
-On failure:  
+**Error cases (normative)**  
+- `Unauthorized` — caller not permitted.  
+- `InvalidAccount` — malformed or disallowed account.  
+- `NotFrozen` — account is not currently frozen.  
+- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+- `GenericError { error_code, message }` — any other failure preventing a valid block.
 
-- `variant { Err : UnfreezeAccountError }`.  
+**Clarifications**  
+- The `tx` field uses **`ts`** for the caller-supplied timestamp (`created_at_time`).  
+- Optional fields **MUST be omitted** from `tx` if not supplied.  
+- Representation-independent hashing (ICRC-3) applies; field presence and value determine hash, not field order.
 
-#### Canonical `tx` Mapping
+#### Canonical `tx` Mapping (normative)
 
-A successful call to `icrc153_unfreeze_account` produces a `123unfreeze_account` block.  
-The `tx` field is derived as follows:
-
-- `op      = "153unfreeze_account"`  
-- `account = UnfreezeAccountArgs.account`  
-- `ts      = UnfreezeAccountArgs.created_at_time`  
-- `caller  = caller_principal (as Blob)`  
-- `reason  = UnfreezeAccountArgs.reason` (if provided)  
-
-Optional fields MUST be omitted if not supplied.
+| Field | Type (ICRC-3 `Value`) | Source / Encoding Rule |
+|---|---|---|
+| `op` | `Text` | **Constant** `"153unfreeze_account"`. |
+| `account` | `Array` (Account) | From `UnfreezeAccountArgs.account`. |
+| `ts` | `Nat` | From `UnfreezeAccountArgs.created_at_time`. |
+| `caller` | `Blob` | Principal of the caller. |
+| `reason` | `Text` *(optional)* | From `UnfreezeAccountArgs.reason` if provided; **omit** if absent. |
 
 
 ### `icrc153_freeze_principal`
@@ -229,35 +240,47 @@ icrc153_freeze_principal : (FreezePrincipalArgs) -> (variant { Ok : nat; Err : F
 
 #### Semantics
 
-- Marks the **principal** as frozen (scope per ICRC-123), affecting its accounts.  
-- Appends a block of type `123freeze_principal`.  
-- On success, returns the **index of the created block**.  
-- On failure, returns an appropriate error.  
-- Semantics are consistent with the freeze semantics defined by ICRC-123.  
+**Authorization**  
+- The method **MUST** be callable only by a **controller** of the ledger or other explicitly authorized principals.  
+- Unauthorized calls **MUST** fail with `Unauthorized`.
 
-#### Return Values
+**Effect (on success, non-retroactive)**  
+- Mark the specified `principal` as **frozen** (scope and effect per ICRC-123), impacting its accounts via composition.  
+- Append a new block with `btype = "123freeze_principal"`.  
+- The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings), with `ts` derived from `created_at_time`.  
+- On success, return the index of the newly appended block.
 
-On success:  
+**Return value**  
+- On success: `variant { Ok : nat }`, where the `nat` is the index of the created block.  
+- On failure: `variant { Err : FreezePrincipalError }`.
 
-- `variant { Ok : nat }` — the created block index.  
+**Deduplication & idempotency**  
+- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
-On failure:  
+**Error cases (normative)**  
+- `Unauthorized` — caller not permitted.  
+- `InvalidPrincipal` — malformed/invalid principal bytes.  
+- `AlreadyFrozen` — principal already frozen at the scope defined by ICRC-123.  
+- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+- `GenericError { error_code, message }` — any other failure preventing a valid block.
 
-- `variant { Err : FreezePrincipalError }`.  
+**Clarifications**  
+- The `tx` field uses **`ts`** for the caller-supplied timestamp (`created_at_time`).  
+- Optional fields **MUST be omitted** from `tx` if not supplied.  
+- Representation-independent hashing (ICRC-3) applies; field presence and value determine hash, not field order.
 
-#### Canonical `tx` Mapping
+#### Canonical `tx` Mapping (normative)
 
-A successful call to `icrc153_freeze_principal` produces a `123freeze_principal` block.  
-The `tx` field is derived as follows:
+| Field | Type (ICRC-3 `Value`) | Source / Encoding Rule |
+|---|---|---|
+| `op` | `Text` | **Constant** `"153freeze_principal"`. |
+| `principal` | `Blob` | From `FreezePrincipalArgs.principal` (principal bytes). |
+| `ts` | `Nat` | From `FreezePrincipalArgs.created_at_time`. |
+| `caller` | `Blob` | Principal of the caller. |
+| `reason` | `Text` *(optional)* | From `FreezePrincipalArgs.reason` if provided; **omit** if absent. |
 
-- `op        = "153freeze_principal"`  
-- `principal = caller-supplied principal (as Blob)`  
-  (in ICRC-3 Value, principals are encoded as `Blob`)  
-- `ts        = FreezePrincipalArgs.created_at_time`  
-- `caller    = caller_principal (as Blob)`  
-- `reason    = FreezePrincipalArgs.reason` (if provided)  
 
-Optional fields MUST be omitted if not supplied.  
 
 
 ### `icrc153_unfreeze_principal`
@@ -286,34 +309,46 @@ icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (variant { Ok : nat; Err
 
 #### Semantics
 
-- Marks the principal as **unfrozen**, lifting restrictions according to ICRC-123 semantics.  
-- Appends a block of type `123unfreeze_principal`.  
-- On success, returns the **index of the created block**.  
-- On failure, returns an appropriate error.  
-- Semantics are consistent with the unfreeze semantics defined by ICRC-123.  
+**Authorization**  
+- The method **MUST** be callable only by a **controller** of the ledger or other explicitly authorized principals.  
+- Unauthorized calls **MUST** fail with `Unauthorized`.
 
-#### Return Values
+**Effect (on success, non-retroactive)**  
+- Mark the specified `principal` as **unfrozen** (lifting restrictions per ICRC-123).  
+- Append a new block with `btype = "123unfreeze_principal"`.  
+- The block’s `tx` field **MUST** be constructed **exactly** as defined in **Canonical `tx` Mapping** (same keys, types, and encodings), with `ts` derived from `created_at_time`.  
+- On success, return the index of the newly appended block.
 
-On success:  
+**Return value**  
+- On success: `variant { Ok : nat }`, where the `nat` is the index of the created block.  
+- On failure: `variant { Err : UnfreezePrincipalError }`.
 
-- `variant { Ok : nat }` — the created block index.  
+**Deduplication & idempotency**  
+- The ledger **MUST** perform deduplication (e.g., using `created_at_time`).  
+- If a duplicate is detected, the ledger **MUST NOT** append a new block and **MUST** return `Err(Duplicate { duplicate_of = <index> })`.
 
-On failure:  
+**Error cases (normative)**  
+- `Unauthorized` — caller not permitted.  
+- `InvalidPrincipal` — malformed/invalid principal bytes.  
+- `NotFrozen` — principal is not currently frozen.  
+- `Duplicate { duplicate_of }` — semantically identical transaction previously accepted.  
+- `GenericError { error_code, message }` — any other failure preventing a valid block.
 
-- `variant { Err : UnfreezePrincipalError }`.  
+**Clarifications**  
+- The `tx` field uses **`ts`** for the caller-supplied timestamp (`created_at_time`).  
+- Optional fields **MUST be omitted** from `tx` if not supplied.  
+- Representation-independent hashing (ICRC-3) applies; field presence and value determine hash, not field order.
 
-#### Canonical `tx` Mapping
+#### Canonical `tx` Mapping (normative)
 
-A successful call to `icrc153_unfreeze_principal` produces a `123unfreeze_principal` block.  
-The `tx` field is derived as follows:
+| Field | Type (ICRC-3 `Value`) | Source / Encoding Rule |
+|---|---|---|
+| `op` | `Text` | **Constant** `"153unfreeze_principal"`. |
+| `principal` | `Blob` | From `UnfreezePrincipalArgs.principal`. |
+| `ts` | `Nat` | From `UnfreezePrincipalArgs.created_at_time`. |
+| `caller` | `Blob` | Principal of the caller. |
+| `reason` | `Text` *(optional)* | From `UnfreezePrincipalArgs.reason` if provided; **omit** if absent. |
 
-- `op        = "153unfreeze_principal"`  
-- `principal = UnfreezePrincipalArgs.principal` (encoded as Blob per ICRC-3 Value)  
-- `ts        = UnfreezePrincipalArgs.created_at_time`  
-- `caller    = caller_principal (as Blob)`  
-- `reason    = UnfreezePrincipalArgs.reason` (if provided)  
-
-Optional fields MUST be omitted if not supplied.
 
 ## Notes on Semantics & Scope
 
@@ -477,7 +512,23 @@ This approach avoids large state updates when freezing/unfreezing principals wit
 while providing a clear, deterministic interpretation of the effective freeze state.
 
 
-## Example calls and the resulting blocks
+## Example: Freeze and Unfreeze — method calls and resulting blocks
+
+> **Encoding note:**  
+> In the example method calls below, principals and accounts are shown in
+> human-readable form (e.g., `principal "abcd..."` or `[principal "abcd..."]`)
+> following Candid notation.  
+>  
+> In the resulting blocks, the same values appear in their canonical
+> **ICRC-3 `Value` representation**, where identifiers are encoded as  
+> `variant { Blob = <raw principal bytes> }` or  
+> `variant { Array = vec { variant { Blob = <owner bytes> } [, variant { Blob = <subaccount bytes> }] } }`.  
+>  
+> These two forms represent the **same identity** — the Candid form is used for
+> readability in examples, while the `Blob` form is the canonical encoding used
+> on-chain for deterministic hashing and certification.
+
+
 
 #### Call
 The caller invokes:
@@ -492,7 +543,7 @@ icrc153_freeze_account({
 
 #### Resulting block
 
-This call rsults in a block with btype="122freeze" and the following contents:
+This call rsults in a block with btype="122freeze_account" and the following contents:
 
 ```
 variant {
@@ -523,11 +574,103 @@ The block records the operation (op = "153freeze_account"), the account being fr
 #### Call
 The caller invokes:
 ```
-icrc153_unfreeze_account({
+iicrc153_unfreeze_account({
   account         = [principal "f5288412af11b299313a5b5a7c128311de102333c4adbe669f2ea1a308"];
-  created_at_time = 1_753_500_100_000_000_000 : nat64;
+  created_at_time = 1_753_500_200_000_000_000 : nat64;
   reason          = ?"Lift compliance hold";
 })
 ```
 
+#### Resulting block
+```
+variant {
+  Map = vec {
+    record { "btype"; variant { Text = "123unfreeze_account" } };
+    record { "phash"; variant { Blob = blob "\9f\aa\10\44\20\19\77\35\c2\9e\00\41\aa\cd\12\ef\04\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88" } }; // illustrative
+    record { "ts";    variant { Nat = 1_753_500_201_000_000_000 : nat } };
+    record {
+      "tx";
+      variant {
+        Map = vec {
+          record { "op";      variant { Text = "153unfreeze_account" } };
+          record { "account"; variant { Array = vec {
+            variant { Blob = blob "\15\28\84\12\af\11\b2\99\31\3a\5b\5a\7c\12\83\11\de\10\23\33\c4\ad\be\66\9f\2e\a1\a3\08" }
+          } } };
+          record { "ts";      variant { Nat  = 1_753_500_200_000_000_000 : nat } };
+          record { "caller";  variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };
+          record { "reason";  variant { Text = "Lift compliance hold" } };
+        }
+      };
+    };
+  }
+};
+```
 
+
+#### Call
+The caller invokes:
+```
+icrc153_freeze_principal({
+  principal       = principal "abcd0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+  created_at_time = 1_753_600_000_000_000_000 : nat64;
+  reason          = ?"KYC review";
+})
+```
+
+#### Resulting block
+```
+variant {
+  Map = vec {
+    record { "btype"; variant { Text = "123freeze_principal" } };
+    record { "phash"; variant { Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99\01\23\45\67\89\ab\cd\ef\10\32\54\76\98\ba\dc\fe" } }; // illustrative
+    record { "ts";    variant { Nat = 1_753_600_001_000_000_000 : nat } };
+    record {
+      "tx";
+      variant {
+        Map = vec {
+          record { "op";        variant { Text = "153freeze_principal" } };
+          record { "principal"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" } };
+          record { "ts";        variant { Nat  = 1_753_600_000_000_000_000 : nat } };
+          record { "caller";    variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };
+          record { "reason";    variant { Text = "KYC review" } };
+        }
+      };
+    };
+  }
+};
+```
+
+#### Call
+The caller invokes:
+
+```
+icrc153_unfreeze_principal({
+  principal       = principal "abcd0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+  created_at_time = 1_753_600_500_000_000_000 : nat64;
+  reason          = ?"KYC cleared";
+})
+```
+
+
+#### Resulting block
+```
+variant {
+  Map = vec {
+    record { "btype"; variant { Text = "123unfreeze_principal" } };
+    record { "phash"; variant { Blob = blob "\fe\dc\ba\98\76\54\32\10\ef\cd\ab\89\67\45\23\01\99\88\77\66\55\44\33\22\11\00\ff\ee\dd\cc\bb\aa" } }; // illustrative
+    record { "ts";    variant { Nat = 1_753_600_501_000_000_000 : nat } };
+    record {
+      "tx";
+      variant {
+        Map = vec {
+          record { "op";        variant { Text = "153unfreeze_principal" } };
+          record { "principal"; variant { Blob = blob "\ab\cd\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab\cd\ef\01\23\45\67\89\ab" } };
+          record { "ts";        variant { Nat  = 1_753_600_500_000_000_000 : nat } };
+          record { "caller";    variant { Blob = blob "\00\00\00\00\02\30\02\17\01\01" } };
+          record { "reason";    variant { Text = "KYC cleared" } };
+        }
+      };
+    };
+  }
+};
+```

--- a/ICRCs/ICRC-153/ICRC-153.md
+++ b/ICRCs/ICRC-153/ICRC-153.md
@@ -309,3 +309,132 @@ Accordingly, ledgers implementing ICRC-153 MUST already advertise support for th
 relevant ICRC-123 block kinds (e.g., `123freeze_account`, `123unfreeze_account`,
 `123freeze_principal`, `123unfreeze_principal`) as required by ICRC-123.
 No additional block types need to be reported.
+
+
+## Query & Introspection Methods
+
+This section defines read-only methods for discovering and checking the current
+freeze state. These queries do **not** produce blocks and are required for
+wallets, explorers, and auditors to efficiently enumerate frozen entities and
+perform quick checks.
+
+All results reflect the ledger’s state **at the time the query is executed**.
+
+
+### `icrc147_list_frozen_accounts`
+
+Lexicographically paginated listing of currently frozen **accounts**.
+
+#### Arguments
+```
+type FrozenAccountsRequest = record {
+    start_after : opt Account;   // return accounts strictly greater than this
+    max_results : nat;
+};
+```
+#### Returns
+```
+type FrozenAccountsResponse = record {
+    accounts : vec Account;
+    has_more : bool;
+};
+
+icrc147_list_frozen_accounts : (FrozenAccountsRequest) -> (FrozenAccountsResponse) query;
+```
+
+
+#### Semantics
+
+- Returns up to `max_results` frozen accounts in **strictly increasing** lexicographic order.
+- If `start_after` is present, the first returned account MUST be **strictly greater** than `start_after`.
+- If `start_after` is absent, the listing starts from the smallest account.
+- `has_more = true` iff there exist additional frozen accounts after the last one returned.
+
+#### Canonical Ordering
+
+Ordering MUST be defined over the ICRC-1 `Account` tuple `(owner, subaccount)` as follows:
+
+1. Compare `owner` by its raw principal **bytes** (as if `variant { Blob = <bytes> }`), lexicographically.
+2. If equal, compare `subaccount`, where:
+   - an absent subaccount sorts **before** a present subaccount;
+   - for two present subaccounts, compare their 32-byte values lexicographically.
+
+This matches the natural `Value::Array`/`Blob` bytewise ordering implied by ICRC-3.
+
+#### Notes
+
+- `max_results` MAY be any non-negative `nat`. If `max_results = 0`, the method returns an empty `accounts` vector and a correct `has_more`.
+- Implementations SHOULD enforce reasonable upper bounds for `max_results` to avoid excessive responses.
+- Results are a **point-in-time snapshot**; concurrent freezes/unfreezes may affect subsequent pages.
+
+### `icrc147_list_frozen_principals`
+
+Lexicographically paginated listing of currently frozen **principals**.
+
+#### Arguments
+```
+type FrozenPrincipalsRequest = record {
+    start_after : opt principal;   // return principals strictly greater than this
+    max_results : nat;
+};
+```
+#### Returns
+```
+type FrozenPrincipalsResponse = record {
+    principals : vec principal;
+    has_more : bool;
+};
+
+icrc147_list_frozen_principals : (FrozenPrincipalsRequest) -> (FrozenPrincipalsResponse) query;
+```
+
+#### Semantics
+
+- Returns up to `max_results` frozen principals in **strictly increasing** lexicographic order.
+- If `start_after` is present, the first returned principal MUST be **strictly greater** than `start_after`.
+- If `start_after` is absent, the listing starts from the smallest principal.
+- `has_more = true` iff there exist additional frozen principals after the last one returned.
+
+#### Canonical Ordering
+
+Principals MUST be ordered by their raw principal **bytes** (as if `variant { Blob = <bytes> }`), lexicographically, consistent with ICRC-3 `Value` ordering.
+
+#### Notes
+
+- `max_results = 0` returns an empty `principals` vector with a correct `has_more`.
+- Implementations SHOULD bound `max_results`.
+- Results are a **point-in-time snapshot**; concurrent changes may affect subsequent pages.
+
+## Effective Freeze Model (Clarification)
+
+ICRC-153 adopts a **compositional freeze rule** consistent with ICRC-123:
+
+- An **account** is *effectively frozen* if **either**:
+  1) the account itself is frozen, **or**
+  2) the account’s `owner` **principal** is frozen.
+
+### Implications for Queries
+
+- `icrc147_list_frozen_accounts`  
+  Returns **only accounts frozen directly** (i.e., via account-level freezes).  
+  It does **not** expand principal-level freezes into per-account entries.
+
+- `icrc147_list_frozen_principals`  
+  Returns **principals** that are frozen. Any account owned by a listed principal is
+  *effectively frozen* by composition, even if it does not appear in the account list.
+
+- `icrc147_is_frozen_account(account)` MUST return `true` if the account is directly frozen
+  **or** if `is_frozen_principal(account.owner)` is `true`.
+
+- `icrc147_is_frozen_principal(principal)` returns whether the **principal-level** freeze is active.
+
+### Integrator Guidance
+
+To determine whether a given account is currently frozen, integrators MUST either:
+- call `icrc147_is_frozen_account(account)`, or
+- check both lists and apply the compositional rule:
+  1) see if `account` appears in `icrc147_list_frozen_accounts`, or
+  2) see if `account.owner` appears in `icrc147_list_frozen_principals`.
+
+This approach avoids large state updates when freezing/unfreezing principals with many accounts,
+while providing a clear, deterministic interpretation of the effective freeze state.


### PR DESCRIPTION
This PR introduces ICRC-523, a standard API for freezing and unfreezing accounts and principals. It defines four privileged methods, canonical tx mapping, and use of the block kinds from ICRC-123. The standard provides auditors, wallets, and integrators with a consistent way to determine whether funds are frozen and to attribute freezes/unfreezes to authorized actors.