### PR TITLE
fix(ICRC-122): post-merge review fixes

### DIFF
--- a/ICRCs/ICRC-122/ICRC-122.md
+++ b/ICRCs/ICRC-122/ICRC-122.md
@@ -135,8 +135,8 @@ This block demonstrates an extended `122burn` including optional provenance and 
 ```
 variant { Map = vec {
     record { "btype"; variant { Text = "122burn" }};
-    record { "ts"; variant { Nat = 1_741_317_147_000_000_000 : nat }};
-    record { "phash"; variant { Blob = blob "\6f\7e\d9\13\75\69\91\bc\d0\0d\04\b6\60\7b\82\f9\e9\62\a8\39\d3\02\80\f2\88\e4\d7\0e\23\2d\29\87" }};
+    record { "ts"; variant { Nat = 1_741_317_148_000_000_000 : nat }};
+    record { "phash"; variant { Blob = blob "\3c\8a\f1\20\b4\55\e7\9d\01\cc\44\87\2e\f9\36\50\da\71\b8\2c\90\e5\af\63\14\d2\7f\88\1b\c3\49\6e" }};
     record { "tx"; variant { Map = vec {
         record { "from"; variant { Array = vec {
             variant { Blob = blob "\00\00\00\00\02\00\01\0d\01\01" };

--- a/ICRCs/ICRC-122/ICRC-122.md
+++ b/ICRCs/ICRC-122/ICRC-122.md
@@ -53,7 +53,7 @@ The `122mint` and `122burn` blocks introduced in ICRC-122 provide a more explici
 - **ICRC-122 Mint/Burn Blocks**:  
   - *Typed Blocks*: This standard defines distinct block types, `122mint` and `122burn`. They are not special cases of `icrc1_transfer`; they represent supply changes directly.  
   - *Minimal Structure*: The minimal `tx` structure contains only the target account (`to` for mint, `from` for burn) and the amount (`amt`). These fields are sufficient to determine the ledger’s state transition.  
-  - *Optional Provenance*: Producers may include additional non-semantic fields in `tx` such as `caller` (the principal that invoked the supply change), `reason` (a human-readable string), or `created_at_time`. These fields aid transparency and auditability but do not affect ledger semantics.  
+  - *Optional Provenance*: Producers may include additional non-semantic fields in `tx` such as `caller` (the principal that invoked the supply change), `reason` (a human-readable string), or `ts` (caller-supplied timestamp). These fields aid transparency and auditability but do not affect ledger semantics.  
   - *Auditability*: By separating the minimal state-changing fields from optional provenance, ICRC-122 ensures clear semantics while still supporting enhanced transparency compared to the ICRC-1 mechanism.  
 
 ### Guidance for Standards That Define Methods
@@ -73,10 +73,10 @@ Such standards SHOULD:
 2. **Define a canonical mapping** from method arguments to the minimal `tx` fields:  
    - `icrcX_mint` → `tx.to`, `tx.amt`.  
    - `icrcX_burn` → `tx.from`, `tx.amt`.  
-   - Optional provenance (`caller`, `reason`, `created_at_time`) MAY be included but MUST NOT affect semantics.  
+   - Optional provenance (`caller`, `reason`, `ts`) MAY be included but MUST NOT affect semantics.  
 
 3. **Document deduplication inputs** (if any). If a method accepts a caller-supplied timestamp,
-   it SHOULD be recorded in `tx.created_at_time` (nanoseconds, MUST fit into `nat64`).  
+   it SHOULD be recorded in `tx.ts` (nanoseconds, MUST fit into `nat64`).  
 
 This guidance ensures that when future standards define mint/burn methods, they can be
 reliably mapped into ICRC-122 block types while remaining compatible with ICRC-3 rules
@@ -108,7 +108,7 @@ The following examples illustrate how `122burn` and `122mint` blocks are encoded
 Each operation is shown in two forms:
 
 - **Minimal form**, which includes only the required fields needed to define the state change.  
-- **Extended form**, which demonstrates how optional provenance fields such as `caller`, `reason`, or `created_at_time` may be included to enhance transparency and auditability.  
+- **Extended form**, which demonstrates how optional provenance fields such as `caller`, `reason`, or `ts` may be included to enhance transparency and auditability.  
 
 These examples are intended to guide implementers and tool builders in interpreting both the essential and optional elements of ICRC-122 blocks.
 
@@ -137,7 +137,7 @@ variant { Map = vec {
 
 
 ### 122burn (Extended Example with Provenance and Deduplication Information)  
-This block demonstrates an extended `122burn` including optional provenance and deduplication information fields (`caller`, `reason`, `created_at_time`) alongside the required fields. These additions provide auditability and deduplication functionality without altering semantics. 
+This block demonstrates an extended `122burn` including optional provenance and deduplication information fields (`caller`, `reason`, `ts`) alongside the required fields. These additions provide auditability and deduplication functionality without altering semantics. 
 
 
 
@@ -154,7 +154,7 @@ variant { Map = vec {
         record { "amt"; variant { Nat = 1_000_000 : nat }};
         record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\00\00\01\01" }};
         record { "reason"; variant { Text = "Token supply adjustment" }};
-        record { "created_at_time"; variant { Nat = 1_741_317_146_900_000_000 : nat }};
+        record { "ts"; variant { Nat = 1_741_317_146_900_000_000 : nat }};
     }}};
 }}
 ```
@@ -181,7 +181,7 @@ variant { Map = vec {
 ---
 
 ### 122mint (Extended Example with Provenance and Deduplication Information)  
-This block demonstrates an extended `122mint` including optional provenance and deduplication fields (`caller`, `reason`, `created_at_time`) alongside the required fields. These additions provide auditability and deduplication functionality without altering semantics.  
+This block demonstrates an extended `122mint` including optional provenance and deduplication fields (`caller`, `reason`, `ts`) alongside the required fields. These additions provide auditability and deduplication functionality without altering semantics.  
 
 
 ```
@@ -197,7 +197,7 @@ variant { Map = vec {
         record { "amt"; variant { Nat = 2_000_000 : nat }};
         record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\00\00\01\01" }};
         record { "reason"; variant { Text = "Initial distribution" }};
-        record { "created_at_time"; variant { Nat = 1_741_317_146_900_000_000 : nat }};
+        record { "ts"; variant { Nat = 1_741_317_146_900_000_000 : nat }};
     }}};
 }}
 ```

--- a/ICRCs/ICRC-122/ICRC-122.md
+++ b/ICRCs/ICRC-122/ICRC-122.md
@@ -1,6 +1,15 @@
 # ICRC-122: Token Burning & Minting Blocks
 
+| Status |
+|:------:|
+| Draft  |
+
 ICRC-122 introduces new block types for recording token minting and burning events in ICRC-compliant ledgers. These blocks provide a standardized way to document authorized supply modifications, ensuring transparent tracking of token issuance and removal. The `122burn` block records token reductions, while the `122mint` block tracks token increases. 
+
+## Dependencies
+
+- **ICRC-3** — Provides the block log format, Value encoding, hashing, certification,
+  and the canonical `tx` mapping rules that this standard extends.
 
 ## Common Elements
 This standard follows the conventions set by ICRC-3, inheriting key structural components.

--- a/ICRCs/ICRC-122/ICRC-122.md
+++ b/ICRCs/ICRC-122/ICRC-122.md
@@ -90,16 +90,9 @@ Ledgers implementing this standard MUST return the following response to `icrc3_
 
 ```candid
 vec {
-    variant { Record = vec {
-        record { "btype"; variant { Text = "122burn" }};
-        record { "url"; variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-122.md" }}; // Placeholder URL
-    }};
-    variant { Record = vec {
-        record { "btype"; variant { Text = "122mint" }};
-        record { "url"; variant { Text = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-122.md" }}; // Placeholder URL
-    }};
+    record { block_type = "122burn"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-122/ICRC-122.md" };
+    record { block_type = "122mint"; url = "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-122/ICRC-122.md" };
 }
-
 ```
 
 ## Example Blocks

--- a/ICRCs/ICRC-122/ICRC-122.md
+++ b/ICRCs/ICRC-122/ICRC-122.md
@@ -113,8 +113,6 @@ Each operation is shown in two forms:
 These examples are intended to guide implementers and tool builders in interpreting both the essential and optional elements of ICRC-122 blocks.
 
 
-### 122burn Example
-
 ### 122burn (Minimal Example)  
 The following block shows the minimal `122burn` structure with only the required `from` and `amt` fields inside the `tx` map.  
 
@@ -218,21 +216,19 @@ produce a `122mint` block on-chain. A possible encoding is shown below:
 
 ```
 variant { Map = vec {
-record { "btype"; variant { Text = "122mint" }};
-record { "ts"; variant { Nat = 1_747_900_000_000_000_000 : nat }};
-record { "phash"; variant { Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99" }};
-record { "tx"; variant { Map = vec {
-// Namespaced op from the method-defining standard (ICRC-145)
-record { "mthd"; variant { Text = "145mint" }};
-// Optional provenance (non-semantic)
-record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\02" }};
-record { "to"; variant { Array = vec {
-variant { Blob = blob "\00\00\00\00\02\00\01\0d\01\01" };
-variant { Blob = blob "\06\ec\cd\3a\97\fb\a8\5f\bc\8d\a3\3e\5d\ba\bc\2f\38\69\60\5d\c7\a1\c9\53\1f\70\a3\66\c5\a7\e4\21" };
-}}};
-record { "amt"; variant { Nat = 1_000_000 : nat }};
-record { "reason"; variant { Text = "Community treasury distribution" }};
-}}};
+    record { "btype"; variant { Text = "122mint" }};
+    record { "ts"; variant { Nat = 1_747_900_000_000_000_000 : nat }};
+    record { "phash"; variant { Blob = blob "\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99\aa\bb\cc\dd\ee\ff\00\11\22\33\44\55\66\77\88\99" }};
+    record { "tx"; variant { Map = vec {
+        record { "mthd";   variant { Text = "145mint" }};
+        record { "caller"; variant { Blob = blob "\00\00\00\00\00\00\f0\0d\01\01" }};
+        record { "to";     variant { Array = vec {
+            variant { Blob = blob "\00\00\00\00\02\00\01\0d\01\01" };
+            variant { Blob = blob "\06\ec\cd\3a\97\fb\a8\5f\bc\8d\a3\3e\5d\ba\bc\2f\38\69\60\5d\c7\a1\c9\53\1f\70\a3\66\c5\a7\e4\21" };
+        }}};
+        record { "amt";    variant { Nat = 1_000_000 : nat }};
+        record { "reason"; variant { Text = "Community treasury distribution" }};
+    }}};
 }}
 ```
 

--- a/ICRCs/ICRC-122/ICRC-122.md
+++ b/ICRCs/ICRC-122/ICRC-122.md
@@ -4,7 +4,12 @@
 |:------:|
 | Draft  |
 
-ICRC-122 introduces new block types for recording token minting and burning events in ICRC-compliant ledgers. These blocks provide a standardized way to document authorized supply modifications, ensuring transparent tracking of token issuance and removal. The `122burn` block records token reductions, while the `122mint` block tracks token increases. 
+ICRC-122 defines two block types for recording authorized token supply changes in ICRC-compliant ledgers:
+
+- **`122mint`** — records a token issuance, crediting a specified account.
+- **`122burn`** — records a token removal, debiting a specified account.
+
+These blocks provide a standardized, auditable representation of privileged supply modifications, distinct from the indirect mint/burn mechanism used by ICRC-1.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Align `tx` timestamp field name with ICRC-152: `created_at_time` → `ts`
- Fix compliance example to use correct Candid encoding and URL path
- Give extended burn example a distinct `phash` and `ts` from the minimal example
- Remove redundant `### 122burn Example` heading
- Fix informative example `caller` blob type byte (`\02` → `\01`) and indentation
- Add Status table and Dependencies section
- Restructure dense single-paragraph introduction

## Test plan

- [ ] Review rendered markdown on GitHub for formatting correctness
- [ ] Verify all `phash` blobs are 32 bytes
- [ ] Verify compliance example matches `icrc3_supported_block_types` return type

🤖 Generated with [Claude Code](https://claude.ai/claude-code)